### PR TITLE
option to provide custom serviceAccount

### DIFF
--- a/charts/octopus-deploy/templates/_helpers.tpl
+++ b/charts/octopus-deploy/templates/_helpers.tpl
@@ -35,5 +35,9 @@ Create chart name and version as used by the chart label.
 The name of the service account to use
 */}}
 {{- define "octopus.serviceAccountName" -}}
+{{- if .Values.octopus.serviceAccount.create -}}
+{{ default (include "octopus.fullname" .) .Values.octopus.serviceAccount.name }}
+{{- else -}}
 {{ default "default" .Values.octopus.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/charts/octopus-deploy/templates/_helpers.tpl
+++ b/charts/octopus-deploy/templates/_helpers.tpl
@@ -30,3 +30,10 @@ Create chart name and version as used by the chart label.
 {{- define "octopus.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+The name of the service account to use
+*/}}
+{{- define "octopus.serviceAccountName" -}}
+{{ default "default" .Values.octopus.serviceAccount.name }}
+{{- end -}}

--- a/charts/octopus-deploy/templates/role.yaml
+++ b/charts/octopus-deploy/templates/role.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.octopus.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: {{ template "octopus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "octopus.fullname" . }}
+rules:
+{{ toYaml .Values.octopus.rbac.role.rules }}
+{{- end }}

--- a/charts/octopus-deploy/templates/rolebinding.yml
+++ b/charts/octopus-deploy/templates/rolebinding.yml
@@ -1,0 +1,18 @@
+{{- if .Values.octopus.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: {{ template "octopus.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "octopus.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "octopus.serviceAccountName" . }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ template "octopus.fullname" . }}
+{{- end }}

--- a/charts/octopus-deploy/templates/serviceaccount.yaml
+++ b/charts/octopus-deploy/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.octopus.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{- with .Values.octopus.serviceAccount.annotations }}
+  annotations:
+{{ tpl (toYaml .) $ | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "octopus.name" . }}
+    chart: {{ template "octopus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.octopus.serviceAccount.labels }}
+  {{ toYaml .Values.octopus.serviceAccount.labels | indent 2 }}
+  {{- end }}
+  name: {{ template "octopus.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.octopus.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+

--- a/charts/octopus-deploy/templates/serviceaccount.yaml
+++ b/charts/octopus-deploy/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.octopus.customServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.octopus.customServiceAccount}}
+automountServiceAccountToken: false
+{{- end }}
+

--- a/charts/octopus-deploy/templates/serviceaccount.yaml
+++ b/charts/octopus-deploy/templates/serviceaccount.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.octopus.customServiceAccount }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{.Values.octopus.customServiceAccount}}
-automountServiceAccountToken: false
-{{- end }}
-

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -35,9 +35,7 @@ spec:
       {{ toYaml .Values.octopus.pods.annotations | indent 2 }}
       {{- end }}
     spec:
-      {{- if .Values.octopus.customServiceAccount }}
-      serviceAccount: {{.Values.octopus.customServiceAccount}}
-      {{- end }}
+      serviceAccount: {{ template "octopus.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 8 }}

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -35,6 +35,9 @@ spec:
       {{ toYaml .Values.octopus.pods.annotations | indent 2 }}
       {{- end }}
     spec:
+      {{- if .Values.octopus.customServiceAccount }}
+      serviceAccount: {{.Values.octopus.customServiceAccount}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 8 }}

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -81,31 +81,30 @@ octopus:
   pods:
     annotations: {}
     labels: {}
-  serviceAccountName:
 
-serviceAccount:
-  create: false
-  ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fullname template
-  name:
-  ## Service Account annotations
-  annotations: {}
-  automountServiceAccountToken: false
-rbac:
-  create: false
-  role:
-    ## Rules to create. It follows the role specification
-    rules:
-      - apiGroups:
-          - ''
-        resources:
-          - services
-          - endpoints
-          - pods
-        verbs:
-          - get
-          - watch
-          - list
+  serviceAccount:
+    create: false
+    ## The name of the ServiceAccount to use.
+    ## If not set and create is true, a name is generated using the fullname template
+    name:
+    ## Service Account annotations
+    annotations: {}
+    automountServiceAccountToken: false
+  rbac:
+    create: false
+    role:
+      ## Rules to create. It follows the role specification
+      rules:
+        - apiGroups:
+            - ''
+          resources:
+            - services
+            - endpoints
+            - pods
+          verbs:
+            - get
+            - watch
+            - list
   
 dockerHub:
   # Set to true to create a secret containing the docker registry password

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -81,11 +81,32 @@ octopus:
   pods:
     annotations: {}
     labels: {}
+  serviceAccountName:
 
-  # Supply a custom service account name if required.  Defaults to "default"
-  serviceAccount:
-    name:
-
+serviceAccount:
+  create: false
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
+  ## Service Account annotations
+  annotations: {}
+  automountServiceAccountToken: false
+rbac:
+  create: false
+  role:
+    ## Rules to create. It follows the role specification
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - services
+          - endpoints
+          - pods
+        verbs:
+          - get
+          - watch
+          - list
+  
 dockerHub:
   # Set to true to create a secret containing the docker registry password
   login: false

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -82,9 +82,9 @@ octopus:
     annotations: {}
     labels: {}
 
-  # set to custom serviceAccount name if you need it, leave blank if no account is needed
-  # you may need it to bind with securityContextConstraints on Openshift for elevated privileges 
-  customServiceAccount: ""
+  # Supply a custom service account name if required.  Defaults to "default"
+  serviceAccount:
+    name:
 
 dockerHub:
   # Set to true to create a secret containing the docker registry password

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -82,6 +82,10 @@ octopus:
     annotations: {}
     labels: {}
 
+  # set to custom serviceAccount name if you need it, leave blank if no account is needed
+  # you may need it to bind with securityContextConstraints on Openshift for elevated privileges 
+  customServiceAccount: ""
+
 dockerHub:
   # Set to true to create a secret containing the docker registry password
   login: false


### PR DESCRIPTION
Useful on Openshift if you need securityContextConstraint set on serviceAccount (Openshift does not allow containers running as root, so all required capabilities need to be set in securityContextConstraint).