### PR TITLE
Allow secrets to be managed by an external provider so the chart values can be saved in git

### DIFF
--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -176,6 +176,7 @@ spec:
         resources:
           requests:
             storage: {{.Values.octopus.serverLogVolume.size}}
+{{- if .Values.octopus.createSecrets }}
 ---
 apiVersion: v1
 kind: Secret
@@ -194,3 +195,4 @@ data:
   {{- end}}
   masterKey: {{.Values.octopus.masterKey | b64enc}}
   dbConnectionString: {{ tpl .Values.octopus.databaseConnectionString . | b64enc}}
+{{- end }}

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -116,7 +116,10 @@ octopus:
             - get
             - watch
             - list
-  
+
+  ## Allows the secrets to be managed via an external secrets provider
+  createSecrets: true
+
 dockerHub:
   # Set to true to create a secret containing the docker registry password
   login: false

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -1,15 +1,24 @@
 octopus:
   # Must be set to "Y" (including the quotes) to accept the EULA at https://octopus.com/legal/customer-agreement
   acceptEula: "N"
+
+  ## Allows the secrets to be managed via an external secrets provider
+  createSecrets: true
+
+  # The below 5 options are not required if createSecrets is false
   # The master key is used to encrypt secrets. Generate a key with: openssl rand 16 | base64
   masterKey: GENERATE_ME
-  databaseConnectionString:
+  databaseConnectionString: GENERATE_ME
   # The Octopus admin username
   username:
   # The Octopus admin password
   password:
+  # the octopus license key in base 64 format
+  licenseKeyBase64:
+
   # The Octopus admin email
   email:
+
   # The Octopus server image. 
   # Visit https://hub.docker.com/r/octopusdeploy/octopusdeploy for the available versions.
   image:
@@ -17,7 +26,6 @@ octopus:
     repository: octopusdeploy/octopusdeploy
     # The tag will default to using the chart appVersion
     tag: 
-  licenseKeyBase64:
   # The port the website is exposed on
   webPort: 80 
   # The port polling tentacles will connect via https://www.octopus.com/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication#polling-tentacles 
@@ -116,9 +124,6 @@ octopus:
             - get
             - watch
             - list
-
-  ## Allows the secrets to be managed via an external secrets provider
-  createSecrets: true
 
 dockerHub:
   # Set to true to create a secret containing the docker registry password


### PR DESCRIPTION
Currently the databaseConnection string is a hard requirement.
For systems like Flux that requires the helm values to be stored in git, this is a problem as the database credentials would need to be in git.

This new option will allow the chart to install but not to manage the secrets. This effectively allows the secrets to be managed by third party operators like sealed-secrets or external-secrets.