### PR TITLE
First pass of a helm chart for kubernetes tentacle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 This repository contains the officially supported [Helm](https://helm.sh) chart for deploying [Octopus Deploy](https://octopus.com).
 
-- [Octopus Deploy](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/octopus-deploy). Self-host the Octopus Deploy server. 
-- Workers. _Coming Soon_
+- [Octopus Deploy](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/octopus-deploy) - Self-host the Octopus Deploy server. 
+- Kubernetes Tentacle - _In Development_
 

--- a/charts/kubernetes-tentacle/.helmignore
+++ b/charts/kubernetes-tentacle/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kubernetes-tentacle/Chart.yaml
+++ b/charts/kubernetes-tentacle/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kubernetes-tentacle
+description: A Helm chart for the Octopus Kubernetes Tentacle
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "8.0.117"

--- a/charts/kubernetes-tentacle/README.md
+++ b/charts/kubernetes-tentacle/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Tentacle Helm Chart
 
 > [!CAUTION]
-> This Helm Chart is a **Work In Progress**. Use at your own risk.
+> This Helm chart is currently **In Development** and should not be used. This chart will be officially released when the chart version is >= 1.0.0
 
-This helm chart is designed to make it easy to install and manage a Tentacle in a Kubernetes Cluster.
+This Helm chart is designed to make it easy to install and manage the Kubernetes Tentacle in a Kubernetes cluster.

--- a/charts/kubernetes-tentacle/README.md
+++ b/charts/kubernetes-tentacle/README.md
@@ -1,0 +1,6 @@
+# Kubernetes Tentacle Helm Chart
+
+> [!CAUTION]
+> This Helm Chart is a **Work In Progress**. Use at your own risk.
+
+This helm chart is designed to make it easy to install and manage a Tentacle in a Kubernetes Cluster.

--- a/charts/kubernetes-tentacle/templates/NOTES.txt
+++ b/charts/kubernetes-tentacle/templates/NOTES.txt
@@ -1,0 +1,1 @@
+This helm chart is currently in development and is not production ready.

--- a/charts/kubernetes-tentacle/templates/_helpers.tpl
+++ b/charts/kubernetes-tentacle/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-tentacle.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-tentacle.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-tentacle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-tentacle.labels" -}}
+helm.sh/chart: {{ include "kubernetes-tentacle.chart" . }}
+{{ include "kubernetes-tentacle.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubernetes-tentacle.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-tentacle.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubernetes-tentacle.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubernetes-tentacle.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubernetes-tentacle.fullname" . }}
+  labels:
+    {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kubernetes-tentacle.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kubernetes-tentacle.labels" . | nindent 8 }}
+	{{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        #   ports:
+        #     - name: http
+        #       containerPort: {{ .Values.service.port }}
+        #       protocol: TCP
+        #   livenessProbe:
+        #     httpGet:
+        #       path: /
+        #       port: http
+        #   readinessProbe:
+        #     httpGet:
+        #       path: /
+        #       port: http
+          env:
+            - name: "AsKubernetesTentacle"
+              value: "True"
+            - name: "ACCEPT_EULA"
+              value: "{{ .Values.tentacle.ACCEPT_EULA }}"
+            - name: "TargetName"
+              value: "{{ .Values.tentacle.targetName }}"
+            - name: "ServerCommsAddress"
+              value: "{{ .Values.tentacle.serverCommsAddress }}"
+            - name: "ServerUrl"
+              value: "{{ .Values.tentacle.serverUrl }}"
+            - name: "DISABLE_DIND"
+              value: "{{ .Values.tentacle.DISABLE_DIND }}"
+            - name: "Space"
+              value: "{{ .Values.tentacle.space }}"
+            - name: "TargetEnvironment"
+              value: "{{ .Values.tentacle.targetEnvironment }}"
+            - name: "TargetRole"
+              value: "{{ .Values.tentacle.targetRole }}"
+            {{- if .Values.tentacle.serverApiKey }}
+            - name: "ServerApiKey"
+              value: "{{ .Values.tentacle.serverApiKey }}"
+            {{- end }}
+            {{- if .Values.tentacle.bearerToken -}}
+            - name: "BearerToken"
+              value: "{{ .Values.tentacle.bearerToken }}"
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kubernetes-tentacle/templates/service.yaml
+++ b/charts/kubernetes-tentacle/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubernetes-tentacle.fullname" . }}
+  labels:
+    {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "kubernetes-tentacle.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kubernetes-tentacle/templates/serviceaccount.yaml
+++ b/charts/kubernetes-tentacle/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+  labels:
+    {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -1,0 +1,88 @@
+# Default values for kubernetes-tentacle.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: docker.packages.octopushq.com/octopusdeploy/tentacle
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+tentacle:
+  ACCEPT_EULA: "N"
+  targetName: ""
+  serverCommsAddress: ""
+  bearerToken: ""
+  serverApiKey: ""
+  serverUrl: ""
+  space: "Default"
+  targetEnvironment: ""
+  targetRole: ""
+  DISABLE_DIND: "Y"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  enabled: false
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
# Background

Part of #project-k8s-agent

We are adding a new helm chart to be used by customers wanting to install the new Kubernetes Tentacle. This helm chart will be used by an install script which will be generated by a wizard in octopus when users request to install a k8s target. This will make the script more succinct and make it easier for customers to manage.

# Results

This is the first pass for the helm chart. It currently works for Polling tentacles only with an input close to this:
<img width="541" alt="Screenshot 2023-11-21 at 12 23 17" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/ea0e3f48-4bc4-4c3d-99cb-e1e7cb38147b">
(It also works with serverApiKey in place of bearer token)

After this is in, we can iterate on it and add functionality. The next thing to add will be to create the appropriate rules for the service account so that it can issue jobs.