### PR TITLE
Significant changes to the Kubernetes Tentacle chart

### DIFF
--- a/charts/kubernetes-tentacle/Chart.yaml
+++ b/charts/kubernetes-tentacle/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.0.117"
+appVersion: "8.0.253"

--- a/charts/kubernetes-tentacle/Chart.yaml
+++ b/charts/kubernetes-tentacle/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.0.253"
+appVersion: "8.0.281-pull-699-linux-amd64"

--- a/charts/kubernetes-tentacle/Chart.yaml
+++ b/charts/kubernetes-tentacle/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.0.281-pull-699-linux-amd64"
+appVersion: "8.0.332"

--- a/charts/kubernetes-tentacle/templates/_helpers.tpl
+++ b/charts/kubernetes-tentacle/templates/_helpers.tpl
@@ -65,8 +65,8 @@ Create the name of the service account to use
 {{- default (printf "%s-job" (include "kubernetes-tentacle.fullname" .)) .Values.serviceAccount.name }}
 {{- end }}
 
-{{- define "kubernetes-tentacle.secrets.installId" -}}
-{{- printf "$s-install-id" ( include "kubernetes-tentacle.fullname" . ) }}
+{{- define "kubernetes-tentacle.secrets.serverAuth" -}}
+{{- printf "%s-server-auth" ( include "kubernetes-tentacle.fullname" . ) }}
 {{- end }}
 
 {{- define "kubernetes-tentacle.jobVolumeYaml" -}}

--- a/charts/kubernetes-tentacle/templates/_helpers.tpl
+++ b/charts/kubernetes-tentacle/templates/_helpers.tpl
@@ -75,5 +75,5 @@ volumes:
   nfs:
     path: /
     readOnly: false
-    server: 10.96.42.42
+    server: {{ .Values.storage.nfsPort }}
 {{- end }}

--- a/charts/kubernetes-tentacle/templates/_helpers.tpl
+++ b/charts/kubernetes-tentacle/templates/_helpers.tpl
@@ -64,3 +64,16 @@ Create the name of the service account to use
 {{- define "kubernetes-tentacle.jobServiceAccountName" -}}
 {{- default (printf "%s-job" (include "kubernetes-tentacle.fullname" .)) .Values.serviceAccount.name }}
 {{- end }}
+
+{{- define "kubernetes-tentacle.secrets.installId" -}}
+{{- printf "$s-install-id" ( include "kubernetes-tentacle.fullname" . ) }}
+{{- end }}
+
+{{- define "kubernetes-tentacle.jobVolumeYaml" -}}
+volumes:
+- name: tentacle-home
+  nfs:
+    path: /
+    readOnly: false
+    server: 10.96.42.42
+{{- end }}

--- a/charts/kubernetes-tentacle/templates/_helpers.tpl
+++ b/charts/kubernetes-tentacle/templates/_helpers.tpl
@@ -30,6 +30,7 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+
 {{/*
 Common labels
 */}}
@@ -54,9 +55,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "kubernetes-tentacle.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "kubernetes-tentacle.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default (include "kubernetes-tentacle.fullname" .) .Values.jobServiceAccount.name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubernetes-tentacle.jobServiceAccountName" -}}
+{{- default (printf "%s-job" (include "kubernetes-tentacle.fullname" .)) .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: "Space"
               value: {{ .Values.tentacle.space | quote }}
             - name: "TargetEnvironment"
-              value: {{ .Values.tentacle.targetEnvironment | quote }}
+              value: {{ join "," .Values.tentacle.targetEnvironment | quote }}
             - name: "TargetRole"
               value: {{ .Values.tentacle.targetRole | quote }}
             - name: "OCTOPUS__K8STENTACLE__NAMESPACE"
@@ -94,7 +94,7 @@ spec:
       volumes:
         - name: nfs-pod
           nfs:
-            server: 10.96.42.42 
+            server: {{ .Values.storage.nfsPort }} 
             path: /
       {{- else if .Values.volumes }}
       volumes:

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -33,8 +33,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubernetes-tentacle.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
 spec:
@@ -26,29 +27,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        #   ports:
-        #     - name: http
-        #       containerPort: {{ .Values.service.port }}
-        #       protocol: TCP
-        #   livenessProbe:
-        #     httpGet:
-        #       path: /
-        #       port: http
-        #   readinessProbe:
-        #     httpGet:
-        #       path: /
-        #       port: http
           env:
-            - name: "AsKubernetesTentacle"
-              value: "True"
             - name: "ACCEPT_EULA"
               value: "{{ .Values.tentacle.ACCEPT_EULA }}"
             - name: "TargetName"
@@ -57,41 +46,37 @@ spec:
               value: "{{ .Values.tentacle.serverCommsAddress }}"
             - name: "ServerUrl"
               value: "{{ .Values.tentacle.serverUrl }}"
-            - name: "DISABLE_DIND"
-              value: "{{ .Values.tentacle.DISABLE_DIND }}"
             - name: "Space"
               value: "{{ .Values.tentacle.space }}"
             - name: "TargetEnvironment"
               value: "{{ .Values.tentacle.targetEnvironment }}"
             - name: "TargetRole"
               value: "{{ .Values.tentacle.targetRole }}"
+            - name: "OCTOPUS__K8STENTACLE__NAMESPACE"
+              value: "{{ .Release.Namespace }}"
+            - name: "OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME"
+              value: "{{ include "kubernetes-tentacle.jobServiceAccountName" . }}"
             {{- if .Values.tentacle.serverApiKey }}
             - name: "ServerApiKey"
               value: "{{ .Values.tentacle.serverApiKey }}"
             {{- end }}
-            {{- if .Values.tentacle.bearerToken -}}
+            {{- if .Values.tentacle.bearerToken }}
             - name: "BearerToken"
               value: "{{ .Values.tentacle.bearerToken }}"
             {{- end }}
+            {{- if .Values.tentacle.listeningPort }}
+            - name: "ListeningPort"
+              value: "{{ .Values.tentacle.listeningPort }}"
+            {{- end }}
+          {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       {{- end }}
       labels:
         {{- include "kubernetes-tentacle.labels" . | nindent 8 }}
-	{{- with .Values.podLabels }}
+	      {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -37,48 +37,66 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end}}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s-linux-amd64" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: "ACCEPT_EULA"
-              value: "{{ .Values.tentacle.ACCEPT_EULA }}"
+              value: {{ .Values.tentacle.ACCEPT_EULA | quote }}
             - name: "TargetName"
-              value: "{{ .Values.tentacle.targetName }}"
+              value: {{ .Values.tentacle.targetName | quote }}
             - name: "ServerCommsAddress"
-              value: "{{ .Values.tentacle.serverCommsAddress }}"
+              value: {{ .Values.tentacle.serverCommsAddress | quote }}
             - name: "ServerUrl"
-              value: "{{ .Values.tentacle.serverUrl }}"
+              value: {{ .Values.tentacle.serverUrl | quote }}
             - name: "Space"
-              value: "{{ .Values.tentacle.space }}"
+              value: {{ .Values.tentacle.space | quote }}
             - name: "TargetEnvironment"
-              value: "{{ .Values.tentacle.targetEnvironment }}"
+              value: {{ .Values.tentacle.targetEnvironment | quote }}
             - name: "TargetRole"
-              value: "{{ .Values.tentacle.targetRole }}"
+              value: {{ .Values.tentacle.targetRole | quote }}
             - name: "OCTOPUS__K8STENTACLE__NAMESPACE"
-              value: "{{ .Release.Namespace }}"
+              value: {{ .Release.Namespace | quote }}
             - name: "OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME"
-              value: "{{ include "kubernetes-tentacle.jobServiceAccountName" . }}"
+              value: {{ include "kubernetes-tentacle.jobServiceAccountName" . | quote }}
+            - name: "OCTOPUS__K8STENTACLE__JOBVOLUMEYAML"
+              value: {{ (include "kubernetes-tentacle.jobVolumeYaml" . | fromYaml).volumes  | toJson  | quote}}
+            - name: "OCTOPUS__K8STENTACLE__FORCE"
+              value: "True"
+            - name: "TentacleHome"
+              value: "/octopus"
+            - name: "TentacleApplications"
+              value: "/octopus/Applications"
             {{- if .Values.tentacle.serverApiKey }}
             - name: "ServerApiKey"
-              value: "{{ .Values.tentacle.serverApiKey }}"
+              value: {{ .Values.tentacle.serverApiKey | quote }}
             {{- end }}
             {{- if .Values.tentacle.bearerToken }}
             - name: "BearerToken"
-              value: "{{ .Values.tentacle.bearerToken }}"
+              value: {{ .Values.tentacle.bearerToken | quote }}
             {{- end }}
             {{- if .Values.tentacle.listeningPort }}
             - name: "ListeningPort"
-              value: "{{ .Values.tentacle.listeningPort }}"
+              value: {{ .Values.tentacle.listeningPort | quote }}
             {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end}}
-          {{- with .Values.volumeMounts }}
+          {{- if .Values.storage.useNFSContainer }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            - mountPath: /octopus
+              name: nfs-pod
+          {{- else if or .Values.volumeMounts }}
+          volumeMounts:
+            {{- .Values.volumeMounts | toYaml | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if .Values.storage.useNFSContainer }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        - name: nfs-pod
+          nfs:
+            server: 10.96.42.42 
+            path: /
+      {{- else if .Values.volumes }}
+      volumes:
+        {{- .Values.volumes | toYaml | nindent 8 }}
       {{- end }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -51,9 +51,9 @@ spec:
             - name: "Space"
               value: {{ .Values.tentacle.space | quote }}
             - name: "TargetEnvironment"
-              value: {{ join "," .Values.tentacle.targetEnvironment | quote }}
+              value: {{ join "," .Values.tentacle.targetEnvironments | quote }}
             - name: "TargetRole"
-              value: {{ .Values.tentacle.targetRole | quote }}
+              value: {{ join "," .Values.tentacle.targetRoles | quote }}
             - name: "OCTOPUS__K8STENTACLE__NAMESPACE"
               value: {{ .Release.Namespace | quote }}
             - name: "OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME"

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -68,11 +68,17 @@ spec:
               value: "/octopus/Applications"
             {{- if .Values.tentacle.serverApiKey }}
             - name: "ServerApiKey"
-              value: {{ .Values.tentacle.serverApiKey | quote }}
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "kubernetes-tentacle.secrets.serverAuth" . }}
+                  key: api-key
             {{- end }}
             {{- if .Values.tentacle.bearerToken }}
             - name: "BearerToken"
-              value: {{ .Values.tentacle.bearerToken | quote }}
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "kubernetes-tentacle.secrets.serverAuth" . }}
+                  key: bearer-token
             {{- end }}
             {{- if .Values.tentacle.listeningPort }}
             - name: "ListeningPort"

--- a/charts/kubernetes-tentacle/templates/job-clusterbinding.yaml
+++ b/charts/kubernetes-tentacle/templates/job-clusterbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubernetes-tentacle.jobServiceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubernetes-tentacle.jobServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kubernetes-tentacle.jobServiceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubernetes-tentacle/templates/job-clusterrole.yaml
+++ b/charts/kubernetes-tentacle/templates/job-clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubernetes-tentacle.jobServiceAccountName" . }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'

--- a/charts/kubernetes-tentacle/templates/job-serviceaccount.yaml
+++ b/charts/kubernetes-tentacle/templates/job-serviceaccount.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+  name: {{ include "kubernetes-tentacle.jobServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.jobServiceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.storage.useNFSContainer }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+      containers:
+        - name: {{ printf "%s-nfs" .Chart.Name }}
+          image: itsthenetwork/nfs-server-alpine:latest
+          securityContext:
+            capabilities:
+                add: ["SYS_ADMIN", "SETPCAP"]
+          env:
+          - name: "SHARED_DIRECTORY"
+            value: "/octopus"
+          - name: "SYNC"
+            value: "true"   
+          ports:
+          - containerPort: 2049
+          volumeMounts:
+          - mountPath: /octopus
+            name: octopus-volume
+      volumes:
+        - name: octopus-volume
+          emptyDir:
+            sizeLimit: 1Gi
+
+{{- end -}}

--- a/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
@@ -28,8 +28,7 @@ spec:
         - name: {{ printf "%s-nfs" .Chart.Name }}
           image: itsthenetwork/nfs-server-alpine:latest
           securityContext:
-            capabilities:
-                add: ["SYS_ADMIN", "SETPCAP"]
+            privileged: true
           env:
           - name: "SHARED_DIRECTORY"
             value: "/octopus"

--- a/charts/kubernetes-tentacle/templates/nfs-service.yaml
+++ b/charts/kubernetes-tentacle/templates/nfs-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.storage.useNFSContainer }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-nfs-svc" (include "kubernetes-tentacle.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  clusterIP: 10.96.42.42
+  selector:
+    app.kubernetes.io/name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
+  ports:
+    - name: nfs
+      port: 2049
+      protocol: TCP
+{{- end }}

--- a/charts/kubernetes-tentacle/templates/nfs-service.yaml
+++ b/charts/kubernetes-tentacle/templates/nfs-service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP
-  clusterIP: 10.96.42.42
+  clusterIP: {{ .Values.storage.nfsPort }}
   selector:
     app.kubernetes.io/name: {{ printf "%s-nfs" (include "kubernetes-tentacle.fullname" .) }}
   ports:

--- a/charts/kubernetes-tentacle/templates/secrets.yaml
+++ b/charts/kubernetes-tentacle/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kubernetes-tentacle.secrets.serverAuth" . }}
+type: Opaque
+data:
+{{- with .Values.tentacle.bearerToken }}
+  bearer-token: {{ . | b64enc }}
+{{- end }}  
+{{- with .Values.tentacle.serverApiKey }}
+  api-key: {{ . | b64enc }}
+{{- end }}

--- a/charts/kubernetes-tentacle/templates/service.yaml
+++ b/charts/kubernetes-tentacle/templates/service.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.service.enabled -}}
+{{- if .Values.tentacle.listeningPort -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubernetes-tentacle.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes-tentacle.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: "LoadBalancer"
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
       protocol: TCP
       name: http
   selector:

--- a/charts/kubernetes-tentacle/templates/serviceaccount.yaml
+++ b/charts/kubernetes-tentacle/templates/serviceaccount.yaml
@@ -10,3 +10,27 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-role" (include "kubernetes-tentacle.serviceAccountName" .) }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["*"]
+  resources: ["jobs"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-binding" (include "kubernetes-tentacle.serviceAccountName" .) }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubernetes-tentacle.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ printf "%s-role" (include "kubernetes-tentacle.serviceAccountName" .) }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -4,13 +4,11 @@
 
 replicaCount: 1
 
-
-
 image:
   repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 tentacle:
   ACCEPT_EULA: "N"
@@ -30,7 +28,7 @@ fullnameOverride: ""
 
 serviceAccount:
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set a name is generated using the fullname template
   name: ""
   # Annotations to add to the service account
   annotations: {}

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -25,6 +25,7 @@ tentacle:
 storage:
   # Change to false if the NFS container should not be used
   useNFSContainer: true
+  nfsPort: 10.0.42.42
 
 imagePullSecrets: []
 nameOverride: ""
@@ -47,27 +48,27 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -22,6 +22,10 @@ tentacle:
   targetRole: ""
   listeningPort: ""
 
+storage:
+  # Change to false if the NFS container should not be used
+  useNFSContainer: true
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -18,8 +18,8 @@ tentacle:
   serverApiKey: ""
   serverUrl: ""
   space: "Default"
-  targetEnvironment: ""
-  targetRole: ""
+  targetEnvironments: []
+  targetRoles: []
   listeningPort: ""
 
 storage:

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -4,11 +4,13 @@
 
 replicaCount: 1
 
+
+
 image:
-  repository: docker.packages.octopushq.com/octopusdeploy/tentacle
+  repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "latest"
 
 tentacle:
   ACCEPT_EULA: "N"
@@ -20,22 +22,24 @@ tentacle:
   space: "Default"
   targetEnvironment: ""
   targetRole: ""
-  DISABLE_DIND: "Y"
+  listeningPort: ""
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account
-  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Annotations to add to the service account
+  annotations: {}
+
+jobServiceAccount:
+  # The name of the service account used for executing jobs
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}
 
 podAnnotations: {}
 podLabels: {}
@@ -50,11 +54,6 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
-service:
-  enabled: false
-  type: ClusterIP
-  port: 80
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -80,9 +79,3 @@ volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}


### PR DESCRIPTION
This PR contains a number of things that bring this up to a "working" Alpha version

- Adds a separate NFS deployment + service for the NFS container that's needed. This has to run in a separate deployment because it's used as a volume in the tentacle pod and if its included in that pod (as a sidecar), the pod doesn't start
- Add service account roles and bindings for the tentacle service account and the job service account
- Add a ton of environment variables to tentacle container
- Remove a bunch of configuration we don't want to allow just yet

I feel like there is a bunch of naming cleanup we should do here, but this is a good start

Shortcut story: [sc-60399]