### PR TITLE
Publish Kubernetes Tentacle chart to Artifactory

### DIFF
--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -24,18 +24,23 @@ jobs:
       - name: Get branch names
         id: branch_names
         uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
+
+      - id: version
+        run: |
+          DATE=$(date '+%Y%m%d%H%M%S')
+          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$DATE" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
       #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'
                     
       - name: Package Chart
-        run: helm package './charts/kubernetes-tentacle' --version '${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}'
+        run: helm package './charts/kubernetes-tentacle' --version '$CHART_VERSION'
 
       - uses: actions/upload-artifact@v3
         name: Upload packaged chart
         with:
-          name: 'kubernetes-tentacle-${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}.tgz'
-          path: '${{ github.workspace }}/kubernetes-tentacle-${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}.tgz'
+          name: 'kubernetes-tentacle-$CHART_VERSION.tgz'
+          path: '${{ github.workspace }}/kubernetes-tentacle-$CHART_VERSION.tgz'
         
       #- name: Push Chart to Artifactory
       #  run: helm push 'kubernetes-tentacle' oci://packages.octopushq.com

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -1,0 +1,27 @@
+name: Publish Chart
+
+on:
+  pull_request:
+  
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+          
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.13.2'
+          
+      - name: Login to DockerHub
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          
+      - name: Package Chart
+        run: helm package --version '${{ inputs.octopus-version }}' --app-version '${{ inputs.octopus-version }}' 'charts/octopus-deploy'
+        
+      - name: Push Chart to DockerHub
+        run: helm push 'octopusdeploy-helm-${{ inputs.octopus-version }}.tgz' oci://registry-1.docker.io/octopusdeploy
+        
+     

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
-      #  run: helm registry login packages.octopushq.com -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
+      #  run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_URL }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
                     
       - name: Package Chart
         run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
@@ -42,4 +42,4 @@ jobs:
           path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
       #- name: Push Chart to Artifactory
-      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://packages.octopushq.com
+      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_URL }}

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -43,12 +43,12 @@ jobs:
         run: |
           pre_release=""
           
-          if [[ "${{steps.branch_names.outputs.branch_name}}" -ne "main" ]]
+          if [[ "ap-publish-to-artifactory" != "main" ]]
           then
               pre_release="-ap-publish-to-artifactory-$(date +'%Y%m%d%H%M%S')"
           fi
           
-          echo "CHART_VERSION=0.1.0$pre_release" >> $GITHUB_ENV
+          echo "CHART_VERSION=0.1.0$pre_release"
           
       - name: Login to Artifactory
         run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - id: version
         run: |
-          DATE=$(date '+%Y%m%d%H%M%S')
-          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$DATE" >> $GITHUB_ENV
+          timestamp=`date +%Y%m%d%H%M%S`
+          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$timestamp" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
       #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pre_release=""
           
-          if [ "${{steps.branch_names.outputs.branch_name}}" -ne "main" ]
+          if [[ "${{steps.branch_names.outputs.branch_name}}" -ne "main" ]]
           then
               pre_release="-ap-publish-to-artifactory-$(date +'%Y%m%d%H%M%S')"
           fi

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -43,9 +43,9 @@ jobs:
         run: |
           pre_release=""
           
-          if [[ "ap-publish-to-artifactory" != "main" ]]
+          if [[ "${{steps.branch_names.outputs.branch_name}}" != "main" ]]
           then
-              pre_release="-ap-publish-to-artifactory-$(date +'%Y%m%d%H%M%S')"
+              pre_release="${{steps.branch_names.outputs.branch_name}}-$(date +'%Y%m%d%H%M%S')"
           fi
           
           echo "CHART_VERSION=0.1.0$pre_release"

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -29,8 +29,8 @@ jobs:
         run: |
           echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
-      #- name: Login to Artifactory
-      #  run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
+      - name: Login to Artifactory
+        run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
                     
       - name: Package Chart
         run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
@@ -41,5 +41,5 @@ jobs:
           name: 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
           path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
-      #- name: Push Chart to Artifactory
-      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}
+      - name: Push Chart to Artifactory
+        run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -14,14 +14,28 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 'v3.13.2'
+
+      - name: Parse Chart config
+        uses: pietrobolcato/action-read-yaml@1.0.0
+        id: read_chart_yaml
+        with:
+          config: ${{ github.workspace }}/charts/kubernetes-tentacle/Chart.yaml
+
+      - name: Get branch names
+        id: branch_names
+        uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
           
-      - name: Login to DockerHub
-        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-          
+      #- name: Login to Artifactory
+      #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'
+                    
       - name: Package Chart
-        run: helm package --version '${{ inputs.octopus-version }}' --app-version '${{ inputs.octopus-version }}' 'charts/octopus-deploy'
+        run: helm package './charts/kubernetes-tentacle' --version '${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}'
+
+      - uses: actions/upload-artifact@v3
+        name: Upload packaged chart
+        with:
+          name: 'kubernetes-tentacle-${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}.tgz'
+          path: '${{ github.workspace }}/kubernetes-tentacle-${{ steps.read_chart_yaml.outputs["version"] }}-${{ steps.branch_names.outputs.branch_name }}.tgz'
         
-      - name: Push Chart to DockerHub
-        run: helm push 'octopusdeploy-helm-${{ inputs.octopus-version }}.tgz' oci://registry-1.docker.io/octopusdeploy
-        
-     
+      #- name: Push Chart to Artifactory
+      #  run: helm push 'kubernetes-tentacle' oci://packages.octopushq.com

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -42,6 +42,7 @@ jobs:
         id: version
         shell: bash
         run: |
+          chart_version="${{ steps.read_chart_yaml.outputs.version }}"
           pre_release=""
           
           if [[ "${{steps.branch_names.outputs.branch_name}}" != "main" ]]
@@ -49,7 +50,7 @@ jobs:
               pre_release="-${{steps.branch_names.outputs.branch_name}}-$(date +'%Y%m%d%H%M%S')"
           fi
           
-          echo "CHART_VERSION=0.1.0$pre_release" >> $GITHUB_ENV
+          echo "CHART_VERSION=$chart_version$pre_release" >> $GITHUB_ENV
           
       - name: Login to Artifactory
         run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
       - name: Login to Artifactory
-        run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
+        run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
                     
       - name: Package Chart
         run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
@@ -42,4 +42,4 @@ jobs:
           path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
       - name: Push Chart to Artifactory
-        run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}
+        run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
-      #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'
+      #  run: helm registry login packages.octopushq.com -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
                     
       - name: Package Chart
         run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
@@ -42,4 +42,4 @@ jobs:
           path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
       #- name: Push Chart to Artifactory
-      #  run: helm push 'kubernetes-tentacle' oci://packages.octopushq.com
+      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://packages.octopushq.com

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
-      #  run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_URL }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
+      #  run: helm registry login ${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'
                     
       - name: Package Chart
         run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
@@ -42,4 +42,4 @@ jobs:
           path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
       #- name: Push Chart to Artifactory
-      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_URL }}
+      #  run: helm push 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz' oci://${{ secret.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -1,6 +1,12 @@
 name: Publish Chart
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - charts/kubernetes-target/**
+      
   pull_request:
     paths:
       - charts/kubernetes-target/**
@@ -28,8 +34,15 @@ jobs:
         uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
 
       - id: version
+        shell: bash
         run: |
-          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+          pre_release=""
+
+          if [ steps.branch_names.outputs.branch_name -ne "main ]; then
+            pre_release="-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')"
+          fi
+          
+          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}$pre_release" >> $GITHUB_ENV
           
       - name: Login to Artifactory
         run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -2,6 +2,8 @@ name: Publish Chart
 
 on:
   pull_request:
+    paths:
+      - charts/kubernetes-target/**
   
 jobs:
   publish:

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -1,4 +1,4 @@
-name: Publish Kubernetes Tentacle to Artifactory
+name: Publish Kubernetes Tentacle chart
 
 on:
   push:
@@ -6,12 +6,15 @@ on:
       - main
     paths:
       - charts/kubernetes-target/**
+      - .github/workflows/kubernetes-tentacle-publish-chart.yaml
       
   pull_request:  
     branches:
       - '*'
     paths:
       - charts/kubernetes-target/**
+      - .github/workflows/kubernetes-tentacle-publish-chart.yaml
+      
   
 jobs:
   publish:

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -48,7 +48,7 @@ jobs:
               pre_release="${{steps.branch_names.outputs.branch_name}}-$(date +'%Y%m%d%H%M%S')"
           fi
           
-          echo "CHART_VERSION=0.1.0$pre_release"
+          echo "CHART_VERSION=0.1.0$pre_release" >> $GITHUB_ENV
           
       - name: Login to Artifactory
         run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -1,4 +1,4 @@
-name: Publish Chart
+name: Publish Kubernetes Tentacle to Artifactory
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
     paths:
       - charts/kubernetes-target/**
       
-  pull_request:
+  pull_request:  
+    branches:
+      - '*'
     paths:
       - charts/kubernetes-target/**
   

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -33,7 +33,7 @@ jobs:
       #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'
                     
       - name: Package Chart
-        run: helm package './charts/kubernetes-tentacle' --version '$CHART_VERSION'
+        run: helm package './charts/kubernetes-tentacle' --version '${{ env.CHART_VERSION }}'
 
       - uses: actions/upload-artifact@v3
         name: Upload packaged chart

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -42,12 +42,13 @@ jobs:
         shell: bash
         run: |
           pre_release=""
-
-          if [ steps.branch_names.outputs.branch_name -ne "main ]; then
-            pre_release="-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')"
+          
+          if [ steps.branch_names.outputs.branch_name -ne "main" ]
+          then
+              pre_release="-ap-publish-to-artifactory-$(date +'%Y%m%d%H%M%S')"
           fi
           
-          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}$pre_release" >> $GITHUB_ENV
+          echo "CHART_VERSION=0.1.0$pre_release" >> $GITHUB_ENV
           
       - name: Login to Artifactory
         run: helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' -p '${{ secrets.ARTIFACTORY_PASSWORD }}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           pre_release=""
           
-          if [ steps.branch_names.outputs.branch_name -ne "main" ]
+          if [ "${{steps.branch_names.outputs.branch_name}}" -ne "main" ]
           then
               pre_release="-ap-publish-to-artifactory-$(date +'%Y%m%d%H%M%S')"
           fi

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -27,8 +27,7 @@ jobs:
 
       - id: version
         run: |
-          timestamp=`date +%Y%m%d%H%M%S`
-          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$timestamp" >> $GITHUB_ENV
+          echo "CHART_VERSION=${{ steps.read_chart_yaml.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
           
       #- name: Login to Artifactory
       #  run: helm registry login packages.octopushq.com -u '${{ }}' -p '${{}}'

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -38,8 +38,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload packaged chart
         with:
-          name: 'kubernetes-tentacle-$CHART_VERSION.tgz'
-          path: '${{ github.workspace }}/kubernetes-tentacle-$CHART_VERSION.tgz'
+          name: 'kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
+          path: '${{ github.workspace }}/kubernetes-tentacle-${{ env.CHART_VERSION }}.tgz'
         
       #- name: Push Chart to Artifactory
       #  run: helm push 'kubernetes-tentacle' oci://packages.octopushq.com

--- a/.github/workflows/kubernetes-tentacle-publish-chart.yaml
+++ b/.github/workflows/kubernetes-tentacle-publish-chart.yaml
@@ -38,14 +38,15 @@ jobs:
         id: branch_names
         uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
 
-      - id: version
+      - name: Generate chart version
+        id: version
         shell: bash
         run: |
           pre_release=""
           
           if [[ "${{steps.branch_names.outputs.branch_name}}" != "main" ]]
           then
-              pre_release="${{steps.branch_names.outputs.branch_name}}-$(date +'%Y%m%d%H%M%S')"
+              pre_release="-${{steps.branch_names.outputs.branch_name}}-$(date +'%Y%m%d%H%M%S')"
           fi
           
           echo "CHART_VERSION=0.1.0$pre_release" >> $GITHUB_ENV


### PR DESCRIPTION
Adds a github action workflow to package the kubernetes tentacle chart, version it with prerelease info and publish to Artifactory

Shortcut story: [sc-66951]