### PR TITLE
Fix versioning workflow

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # For all pushes that aren't creating a versioning commit
-    if: ${{ !startsWith(github.event.commits[0].message, "Version Kubernetes Tentacle Chart" }}
+    if: ${{ !startsWith(github.event.commits[0].message, "Version Kubernetes Tentacle Chart") }}
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
Turns out having an invalid workflow doesn't give you a red build if that workflow doesn't run :(