### PR TITLE
Support configuring tolerations and resources

### DIFF
--- a/.github/workflows/octopus-publish-chart.yml
+++ b/.github/workflows/octopus-publish-chart.yml
@@ -1,4 +1,4 @@
-name: Publish Chart
+name: Publish Octopus Deploy Chart
 
 on:
 
@@ -19,7 +19,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: 'v3.11.1'
+          version: 'v3.13.2'
           
       - name: Login to DockerHub
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin

--- a/.github/workflows/octopus-tests.yaml
+++ b/.github/workflows/octopus-tests.yaml
@@ -1,0 +1,21 @@
+name: Run helm tests on Octopus chart 
+
+on:
+  push:
+    paths:
+    - charts/octopus-deploy/**
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.2
+    - name: Run Helm unit tests
+        run: |
+          helm plugin install https://github.com/quintush/helm-unittest
+          helm unittest charts/octopus-deploy

--- a/.github/workflows/octopus-tests.yaml
+++ b/.github/workflows/octopus-tests.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.13.2
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.13.2
     - name: Run Helm unit tests
-        run: |
-          helm plugin install https://github.com/quintush/helm-unittest
-          helm unittest charts/octopus-deploy
+      run: |
+        helm plugin install https://github.com/quintush/helm-unittest
+        helm unittest charts/octopus-deploy

--- a/.github/workflows/octopus-tests.yaml
+++ b/.github/workflows/octopus-tests.yaml
@@ -5,6 +5,9 @@ on:
     paths:
     - charts/octopus-deploy/**
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/octopus-tests.yaml
+++ b/.github/workflows/octopus-tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
     - charts/octopus-deploy/**
+    - .github/workflows/octopus-tests.yaml
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -44,10 +44,10 @@ spec:
       affinity:
       {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+    {{- with .Values.octopus.tolerations }}
       tolerations:
-      {{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
       containers:
               - name: octopus
                 image: "{{ .Values.octopus.image.repository }}:{{ default .Chart.AppVersion .Values.octopus.image.tag }}"

--- a/charts/octopus-deploy/tests/statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/statefulset_test.yaml
@@ -24,3 +24,19 @@ tests:
             operator: "Exists"
             effect: "NoSchedule"
         documentIndex: 0
+
+  - it: resources are configurable
+    values: 
+      - ./values/required.yaml
+      - ./values/resources.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources
+          value: 
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+        documentIndex: 0

--- a/charts/octopus-deploy/tests/statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/statefulset_test.yaml
@@ -1,0 +1,26 @@
+suite: statefulset 
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: statefulset should render
+    values: 
+      - ./values/required.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+        documentIndex: 0
+      - hasDocuments:
+          count: 2 # There is a secret created as well as the stateful set
+  
+  - it: tolerances are configurable
+    values: 
+      - ./values/tolerations.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content: 
+            key: "example-key"
+            operator: "Exists"
+            effect: "NoSchedule"
+        documentIndex: 0

--- a/charts/octopus-deploy/tests/values/required.yaml
+++ b/charts/octopus-deploy/tests/values/required.yaml
@@ -1,0 +1,21 @@
+octopus:
+  acceptEula: "Y" # It is required to accept the Octopus EULA https://octopus.com/legal/customer-agreement
+  masterKey: F/lC1w09INVvEceNW1+28A== 
+  databaseConnectionString: Server=tcp:octopus.database.windows.net,1433;Initial Catalog=OctopusDeploy;Persist Security Info=False;User ID=octopus;Password=abracadabra;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
+  licenseKeyBase64: GBxpY2Vuc2UgU2lnbmF0dxJlPSJGNmgxakh2K0pVTEk2ekVES1Azc1hHWDgwdzltOGU2ekl5d3QyUCtKeEdxbnJOMVBZQXBaQTlGbkV5MGxRMDBrdHNmTTNXeG9ObnVFR1UzWVBXSUF3dz09Ij4KICA8TGljZW5zZWRUbz5PY3RvcHVzIERlcGxveTwvTGljZW5zZWRUbz4KICA8TGljZW5zZUtleT4zMjAyOS0yODMwNy04NjQyMS05MTQ1OTwvTGljZW5zZUtleT4KICA8VmVyc2lvbj4yLjA8IS0tIExpY2Vuc2UgU3NoZW1hIFZlbnNpb24gLS0+PC9WZXJzaW9uPgogIDxWYWxpZEZyb20+MjAyMC0wNy0yMDwvVmFsaWRGcm9tPgogIDxGZWF0dXJlcz4KICAgIDxJbnNpZ2h0cz4KICAgICAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICAgIDwvSW5zaWdodHM+CiAgICA8SmlyYVNlcnZpY2VNYW5hZ2VtZW50SW50ZWdyYXRpb24+CiAgICAgIDxWYWxpZFRvPjIwMjMtMDktMDQ8L1ZhbGlkVG8+CiAgICA8L0ppcmFTZXJ2aWNlTWFuYWdlbWVudEludGVncmF0aW9uPgogICAgPFNlcnZpY2VOb3dJbnRlZ3JhdGlvbj4KICAgICAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICAgIDwvU2VydmljZU5vd0ludGVncmF0aW9uPgogIDwvRmVhdHVyZXM+CiAgPEtpbmQ+VHJpYWw8L0tpbmQ+CiAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICA8UHJvamVjdExpbWl0PlVubGltaXRlZDwvUHJvamVjdExpbWl0PgogIDxNYWNoaW5lTGltaXQ+VW5saW1pdGVkPC9NYWNoaW5lTGltaXQ+CiAgPFVzZXJMaW1pdD5VbmxpbWl0ZWQ8L1VzZXJMaW1pdD4KICA8Tm9kZUxpbWl0PlVubGltaXRlZDwvTm9kZUxpbWl0PgogIDxTcGFjZUxpbWl0PlVubGltaXRlZDwvU3BhY2VMaW1pdD4KPC9MaWNlbnNlPg==
+  username: admin 
+  password: abracadabra 
+  packageRepositoryVolume:
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce
+  # The volume used for persisting deployment artifacts: https://octopus.com/docs/projects/deployment-process/artifacts
+  artifactVolume:
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce
+ # Volume used for task logs: https://octopus.com/docs/support/get-the-raw-output-from-a-task
+  taskLogVolume: 
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce

--- a/charts/octopus-deploy/tests/values/resources.yaml
+++ b/charts/octopus-deploy/tests/values/resources.yaml
@@ -1,0 +1,8 @@
+octopus:
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "250m"
+    limits:
+      memory: "128Mi"
+      cpu: "500m"

--- a/charts/octopus-deploy/tests/values/tolerations.yaml
+++ b/charts/octopus-deploy/tests/values/tolerations.yaml
@@ -1,0 +1,25 @@
+octopus:
+  tolerations:
+  - key: "example-key"
+    operator: "Exists"
+    effect: "NoSchedule"
+  acceptEula: "Y" # It is required to accept the Octopus EULA https://octopus.com/legal/customer-agreement
+  masterKey: F/lC1w09INVvEceNW1+28A== 
+  databaseConnectionString: Server=tcp:octopus.database.windows.net,1433;Initial Catalog=OctopusDeploy;Persist Security Info=False;User ID=octopus;Password=abracadabra;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
+  licenseKeyBase64: GBxpY2Vuc2UgU2lnbmF0dxJlPSJGNmgxakh2K0pVTEk2ekVES1Azc1hHWDgwdzltOGU2ekl5d3QyUCtKeEdxbnJOMVBZQXBaQTlGbkV5MGxRMDBrdHNmTTNXeG9ObnVFR1UzWVBXSUF3dz09Ij4KICA8TGljZW5zZWRUbz5PY3RvcHVzIERlcGxveTwvTGljZW5zZWRUbz4KICA8TGljZW5zZUtleT4zMjAyOS0yODMwNy04NjQyMS05MTQ1OTwvTGljZW5zZUtleT4KICA8VmVyc2lvbj4yLjA8IS0tIExpY2Vuc2UgU3NoZW1hIFZlbnNpb24gLS0+PC9WZXJzaW9uPgogIDxWYWxpZEZyb20+MjAyMC0wNy0yMDwvVmFsaWRGcm9tPgogIDxGZWF0dXJlcz4KICAgIDxJbnNpZ2h0cz4KICAgICAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICAgIDwvSW5zaWdodHM+CiAgICA8SmlyYVNlcnZpY2VNYW5hZ2VtZW50SW50ZWdyYXRpb24+CiAgICAgIDxWYWxpZFRvPjIwMjMtMDktMDQ8L1ZhbGlkVG8+CiAgICA8L0ppcmFTZXJ2aWNlTWFuYWdlbWVudEludGVncmF0aW9uPgogICAgPFNlcnZpY2VOb3dJbnRlZ3JhdGlvbj4KICAgICAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICAgIDwvU2VydmljZU5vd0ludGVncmF0aW9uPgogIDwvRmVhdHVyZXM+CiAgPEtpbmQ+VHJpYWw8L0tpbmQ+CiAgPFZhbGlkVG8+MjAyMy0wOS0wNDwvVmFsaWRUbz4KICA8UHJvamVjdExpbWl0PlVubGltaXRlZDwvUHJvamVjdExpbWl0PgogIDxNYWNoaW5lTGltaXQ+VW5saW1pdGVkPC9NYWNoaW5lTGltaXQ+CiAgPFVzZXJMaW1pdD5VbmxpbWl0ZWQ8L1VzZXJMaW1pdD4KICA8Tm9kZUxpbWl0PlVubGltaXRlZDwvTm9kZUxpbWl0PgogIDxTcGFjZUxpbWl0PlVubGltaXRlZDwvU3BhY2VMaW1pdD4KPC9MaWNlbnNlPg==
+  username: admin 
+  password: abracadabra 
+  packageRepositoryVolume:
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce
+  # The volume used for persisting deployment artifacts: https://octopus.com/docs/projects/deployment-process/artifacts
+  artifactVolume:
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce
+ # Volume used for task logs: https://octopus.com/docs/support/get-the-raw-output-from-a-task
+  taskLogVolume: 
+    size: 1Gi 
+    storageClassName: "azure-file"
+    storageAccessMode: ReadWriteOnce

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -93,7 +93,14 @@ octopus:
     annotations: {}
     labels: {}
 
+  # For minimum resource indications see https://octopus.com/docs/administration/managing-infrastructure/performance#minimum-requirements 
   resources: {} 
+  #  requests:
+  #    memory: "400M"
+  #    cpu: "100m"
+  #  limits:
+  #    memory: "4G"
+  #    cpu: "1"
 
   tolerations: [] 
 

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -93,6 +93,8 @@ octopus:
     annotations: {}
     labels: {}
 
+  tolerations: [] 
+
   serviceAccount:
     create: false
     ## The name of the ServiceAccount to use.

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -93,6 +93,8 @@ octopus:
     annotations: {}
     labels: {}
 
+  resources: {} 
+
   tolerations: [] 
 
   serviceAccount:


### PR DESCRIPTION
Tolerations and Resources can now be supplied via values.  e.g.

```
octopus:
  tolerations:
  - key: "example-key"
    operator: "Exists"
    effect: "NoSchedule"

  resources:
    requests:
      memory: "64Mi"
      cpu: "250m"
    limits:
      memory: "128Mi"
      cpu: "500m"
```

Closes https://github.com/OctopusDeploy/helm-charts/issues/22
