### PR TITLE
Change to support config map data for tentacle registration

### DIFF
--- a/charts/kubernetes-tentacle/.changeset/violet-toes-wait.md
+++ b/charts/kubernetes-tentacle/.changeset/violet-toes-wait.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-tentacle": patch
+---
+
+Allow Tentacle service account to interact with config maps

--- a/charts/kubernetes-tentacle/templates/configmap.yaml
+++ b/charts/kubernetes-tentacle/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "tentacle-config-map"
+data:
+  is_registered: "true"

--- a/charts/kubernetes-tentacle/templates/configmap.yaml
+++ b/charts/kubernetes-tentacle/templates/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "tentacle-config-map"
-data:
-  is_registered: "true"

--- a/charts/kubernetes-tentacle/templates/serviceaccount.yaml
+++ b/charts/kubernetes-tentacle/templates/serviceaccount.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: ["*"]
   resources: ["jobs"]
   verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["configmaps"]
+  verbs: ["patch", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/kubernetes-tentacle/templates/serviceaccount.yaml
+++ b/charts/kubernetes-tentacle/templates/serviceaccount.yaml
@@ -22,7 +22,7 @@ rules:
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["configmaps"]
-  verbs: ["patch", "get"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
# Background

Part of #project-k8s-agent

# Details

We need to allow the Tentacle to read and edit config maps so that it can save it's configuration to a config map.

We need to save the Tentacle's configuration in a config map to ensure that it's able to recover if either the NFS volume or the tentacle container goes down and comes back up. This can happen at any time in Kubernetes due to load balancing.