### PR TITLE
Additional k8s tentacle updates to support configuration stored in config map

### DIFF
--- a/charts/kubernetes-tentacle/.changeset/stupid-rivers-serve.md
+++ b/charts/kubernetes-tentacle/.changeset/stupid-rivers-serve.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-tentacle": patch
+---
+
+Add minor changes to support tentacles using configmap for configuration storage

--- a/charts/kubernetes-tentacle/package-lock.json
+++ b/charts/kubernetes-tentacle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubernetes-tentacle",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubernetes-tentacle",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@changesets/cli": "^2.27.1"
       }

--- a/charts/kubernetes-tentacle/templates/configmap.yaml
+++ b/charts/kubernetes-tentacle/templates/configmap.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "kubernetes-tentacle.fullname" . }}-configmap"

--- a/charts/kubernetes-tentacle/templates/configmap.yaml
+++ b/charts/kubernetes-tentacle/templates/configmap.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ include "kubernetes-tentacle.fullname" . }}-configmap"
+  name: tentacle-config
+  namespace: {{ .Release.Namespace | quote }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.tentacle.ACCEPT_EULA | quote }}
-            - name: "instanceName"
+            - name: "InstanceName"
               value: {{ include "kubernetes-tentacle.fullname" . }}
             - name: "TargetName"
               value: {{ .Values.tentacle.targetName | quote }}

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.tentacle.ACCEPT_EULA | quote }}
+            - name: "instanceName"
+              value: {{ include "kubernetes-tentacle.fullname" . }}
             - name: "TargetName"
               value: {{ .Values.tentacle.targetName | quote }}
             - name: "ServerCommsAddress"

--- a/charts/kubernetes-tentacle/templates/deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/deployment.yaml
@@ -42,8 +42,6 @@ spec:
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.tentacle.ACCEPT_EULA | quote }}
-            - name: "InstanceName"
-              value: {{ include "kubernetes-tentacle.fullname" . }}
             - name: "TargetName"
               value: {{ .Values.tentacle.targetName | quote }}
             - name: "ServerCommsAddress"

--- a/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-tentacle/templates/nfs-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: {{ include "kubernetes-tentacle.serviceAccountName" . }}
       containers:
         - name: {{ printf "%s-nfs" .Chart.Name }}
-          image: itsthenetwork/nfs-server-alpine:latest
+          image: "itsthenetwork/nfs-server-alpine:latest{{ .Values.development.nfs.useArmContainer | ternary "-arm" "" }}"
           securityContext:
             privileged: true
           env:

--- a/charts/kubernetes-tentacle/values.yaml
+++ b/charts/kubernetes-tentacle/values.yaml
@@ -82,3 +82,7 @@ volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
+
+development:
+  nfs:
+    useArmContainer: false


### PR DESCRIPTION
# Background

This is part of #project-k8s-agent. We are updating the agent to save all it's configuration in a config map to ensure that it's not lost if either the nfs or the tentacle pod goes down.

# Changes

1. I've added in an empty config map to the helm chart so that if you uninstall the tentacle via helm, it will clean up the configmap. Previously it would leave it behind because it was created by the tentacle itself and not by helm.

2. I've also added in an `InstanceName` env var because this is used to get the name of the config map. This means that each k8s tentacle in an instance needs to have a unique instance name, we just pass in the 'fullname' from the helm chart which is unique for targets as it's based off the target name. This change will coincide with changes made to the install script in Tentacle.

3. Lastly I've added the ability to specify if you want to use the arm nfs container. This is in a new "developer" object as it's only really required when running locally on an M1 mac or other arm based development machine.