### PR TITLE
Update package-lock.json version

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -44,11 +44,14 @@ jobs:
 
     - name: 'Update version and commit Chart.yaml'
       run: |
-        version=$(jq -r .version ./charts/kubernetes-agent/package.json)
-        version="$version" yq -i '.version = strenv(version)' ./charts/kubernetes-agent/Chart.yaml
+        cd ./charts/kubernetes-agent
+        version=$(jq -r .version package.json)
+        version="$version" yq -i '.version = strenv(version)' Chart.yaml
+        npm i --package-lock-only
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        git add ./charts/kubernetes-agent/Chart.yaml
+        git add Chart.yaml
+        git add package-lock.json
         git commit -m "Update Chart.yaml"
         git push --set-upstream origin changeset-release/main
       if: steps.changesets.outputs.hasChangesets == 'true'


### PR DESCRIPTION
When the changeset updates the `package.json` version, it doesn't update the `package-lock.json` version, meaning that subsequent PR's have to include this pointless update.

This updates the versioning workflow to run `npm i --package-lock-only` to force npm to update the version in the lock file