### PR TITLE
Use new multi-arch tentacle image

### DIFF
--- a/charts/kubernetes-agent/.changeset/bright-camels-fix.md
+++ b/charts/kubernetes-agent/.changeset/bright-camels-fix.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update helm chart to use multi-arch tentacle container image

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.2.2"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.671"
+appVersion: "8.1.707"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end}}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s-linux-amd64" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: "ACCEPT_EULA"


### PR DESCRIPTION
# Background

Part of #project-k8s-agent.

[I've recently updated](https://github.com/OctopusDeploy/OctopusTentacle/pull/781) the way we build the kubernetes tentacle container image, so now it builds as a multi-arch image. This means that we don't need to postfix the container tag with `-linux-{arch}`.

# Results

I've removed the postfix from the tentacle image tag and I've updated the tentacle version to the first version which will support the new multi-arch image.