### PR TITLE
Update to multi-arch nfs-server container image

### DIFF
--- a/charts/kubernetes-agent/.changeset/warm-melons-check.md
+++ b/charts/kubernetes-agent/.changeset/warm-melons-check.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update agent to use Octopus managed nfs server container image

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: {{ printf "%s-nfs" (include "kubernetes-agent.name" .) }}
-          image: "itsthenetwork/nfs-server-alpine:latest{{ .Values.development.nfs.useArmContainer | ternary "-arm" "" }}"
+          image: "docker.packages.octopushq.com/octopusdeploy/nfs-server:latest"
           securityContext:
             privileged: true
           env:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -81,7 +81,3 @@ volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
-
-development:
-  nfs:
-    useArmContainer: false


### PR DESCRIPTION
# Background

Part of #project-k8s-agent.

To make the helm-chart simpler, I've forked the nfs-server repository and added a Github Action which builds the container image as a multi-arch image. https://github.com/OctopusDeploy/nfs-server-alpine

# Results

We can now remove the janky variable that was required when installing the agent on arm64 hosts.