### PR TITLE
Specify Linux as the target nodes

### DIFF
--- a/charts/kubernetes-agent/.changeset/shiny-mirrors-taste.md
+++ b/charts/kubernetes-agent/.changeset/shiny-mirrors-taste.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Set node OS affinity to Linux nodes

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -41,6 +41,8 @@ spec:
       volumes:
         - name: octopus-volume
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: 1Gi      
+      nodeSelector:
+        kubernetes.io/os: "linux"
 
 {{- end -}}

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       volumes:
         - name: octopus-volume
           emptyDir:
-            sizeLimit: 1Gi      
+            sizeLimit: 1Gi
       nodeSelector:
         kubernetes.io/os: "linux"
 

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -100,6 +100,8 @@ spec:
           volumeMounts:
             {{- .Values.volumeMounts | toYaml | nindent 12 }}
           {{- end }}
+      nodeSelector:
+        kubernetes.io/os: "linux"
       {{- if .Values.storage.useNFSContainer }}
       volumes:
         - name: nfs-pod


### PR DESCRIPTION
We only support running on Linux, so force the node selection for the two deployments

Shortcut story: [sc-70536]