### PR TITLE
Add resource requests for NFS & Agent containers

### DIFF
--- a/charts/kubernetes-agent/.changeset/fuzzy-oranges-bow.md
+++ b/charts/kubernetes-agent/.changeset/fuzzy-oranges-bow.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Add resource requests for NFS & Agent containers

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.3.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.761"
+appVersion: "8.1.778"

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -28,6 +28,10 @@ spec:
           image: "docker.packages.octopushq.com/octopusdeploy/nfs-server:latest"
           securityContext:
             privileged: true
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 50m
           env:
           - name: "SHARED_DIRECTORY"
             value: "/octopus"

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -30,8 +30,8 @@ spec:
             privileged: true
           resources:
             requests:
-              memory: 50Mi
-              cpu: 50m
+              memory: "50Mi"
+              cpu: "50m"
           env:
           - name: "SHARED_DIRECTORY"
             value: "/octopus"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -41,8 +41,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             requests:
-              memory: 100Mi
-              cpu: 100m
+              memory: "100Mi"
+              cpu: "100m"
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.tentacle.ACCEPT_EULA | quote }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             requests:
-              memory: "100Mi"
+              memory: "150Mi"
               cpu: "100m"
           env:
             - name: "ACCEPT_EULA"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -39,6 +39,10 @@ spec:
           {{- end}}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.tentacle.ACCEPT_EULA | quote }}


### PR DESCRIPTION
To be good Kubernetes citizens, we need to set resource requests for our containers.

Based on testing on an AKS cluster, these limits seem quite reasonable

Shortcut story: [sc-70554]

## NFS 

### CPU
![image](https://github.com/OctopusDeploy/helm-charts/assets/332730/fcd76f43-60d9-4755-9750-bc4707ff48d5)

### Memory
![image](https://github.com/OctopusDeploy/helm-charts/assets/332730/48c8a003-e757-459c-9422-64b17729312a)


## Agent

## CPU

![image](https://github.com/OctopusDeploy/helm-charts/assets/332730/b9fe6a64-73e0-485c-bc1d-b2c7029b66b9)

## Memory

![image](https://github.com/OctopusDeploy/helm-charts/assets/332730/3ae1182e-4b81-4816-aea6-ec9c078d6e3e)

