### PR TITLE
Publish main versions to DockerHub

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -66,3 +66,12 @@ jobs:
 
     - name: Push Chart to Artifactory
       run: helm push 'kubernetes-agent-${{ env.CHART_VERSION }}.tgz' oci://${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}
+
+    - name: Login to DockerHub
+      if: github.ref == 'refs/heads/main'
+      run: helm registry login registry-1.docker.io -u '${{ secrets.DOCKERHUB_USERNAME }}' -p '${{ secrets.DOCKERHUB_TOKEN }}'
+    
+    - name: Push Chart to DockerHub    
+      if: github.ref == 'refs/heads/main'
+      run: helm push 'kubernetes-agent-${{ env.CHART_VERSION }}.tgz' oci://registry-1.docker.io/octopusdeploy
+      

--- a/charts/kubernetes-agent/templates/NOTES.txt
+++ b/charts/kubernetes-agent/templates/NOTES.txt
@@ -1,1 +1,2 @@
-This is the official Helm Chart for the Octopus Deploy Kubernetes Agent. This helm chart is currently in development and is not production ready.
+WARNING: This Helm chart is currently in development and is not production ready.
+This is the official Helm chart for the Octopus Deploy Kubernetes Agent.

--- a/charts/kubernetes-agent/templates/NOTES.txt
+++ b/charts/kubernetes-agent/templates/NOTES.txt
@@ -1,1 +1,1 @@
-This helm chart is currently in development and is not production ready.
+This is the official Helm Chart for the Octopus Deploy Kubernetes Agent. This helm chart is currently in development and is not production ready.


### PR DESCRIPTION
We are close enough to the release of the Kubernetes Agent that I feel comfortable publishing pre-release versions of the Kubernetes Helm Chart to DockerHub.

This will allow us to update the UI in Octopus Server with the Docker Hub URL

Shortcut story: [sc-70653]