### PR TITLE
Change to use DockerHub hosted images

### DIFF
--- a/charts/kubernetes-agent/.changeset/eighty-coats-give.md
+++ b/charts/kubernetes-agent/.changeset/eighty-coats-give.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Change to use DockerHub hosted container images

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: {{ printf "%s-nfs" (include "kubernetes-agent.name" .) }}
-          image: "docker.packages.octopushq.com/octopusdeploy/nfs-server:latest"
+          image: "octopusdeploy/nfs-server:latest"
           securityContext:
             privileged: true
           resources:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle
+  repository: octopusdeploy/kubernetes-tentacle
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Now we are publishing both the nfs-server and kubernetes-tentacle containers to dockerhub, so lets use them!