### PR TITLE
Add tentacle log level env var and variable to change it

### DIFF
--- a/charts/kubernetes-agent/.changeset/moody-shirts-sniff.md
+++ b/charts/kubernetes-agent/.changeset/moody-shirts-sniff.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Add Tentacle LogLevel environment variable

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -70,6 +70,8 @@ spec:
               value: {{ .Release.Name | quote}}
             - name: "OCTOPUS__K8STENTACLE__HELMCHARTVERSION"
               value: {{ .Chart.Version | quote}}
+            - name: "OCTOPUS__TENTACLE__LOGLEVEL"
+              value: {{ .Values.tentacle.logLevel | default "Debug" }}
             - name: "TentacleHome"
               value: "/octopus"
             - name: "TentacleApplications"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -21,6 +21,7 @@ tentacle:
   targetEnvironments: []
   targetRoles: []
   listeningPort: ""
+  logLevel: ""
 
 storage:
   # Change to false if the NFS container should not be used


### PR DESCRIPTION
# Background

#project-k8s-agent

In conjunction with this tentacle PR: https://github.com/OctopusDeploy/OctopusTentacle/pull/803

This allows users to set the loglevel of tentacle in the helm chart. By default it is set to Debug (which is the same as Verbose)

[sc-69229]