### PR TITLE
Bump tentacle version

### DIFF
--- a/.changeset/dry-tigers-destroy.md
+++ b/.changeset/dry-tigers-destroy.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Bump tentacle version to test automated updates in server

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.4.4"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.858"
+appVersion: "8.1.861"


### PR DESCRIPTION
This new version doesn't contain any significant changes for the k8s agent but I'll use it to test if the automatic updates work correctly.