### PR TITLE
Add hello-octo test helm chart

### DIFF
--- a/.changeset/bright-readers-drive.md
+++ b/.changeset/bright-readers-drive.md
@@ -1,0 +1,5 @@
+---
+"hello-octo": patch
+---
+
+First issue of test helm chart "hello octo"

--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -40,8 +40,8 @@ jobs:
       id: changesets
       uses: changesets/action@v1
       with:
-        commit: 'Version Kubernetes Agent Chart'
-        title: 'Version Kubernetes Agent Chart'
+        commit: 'Version Helm Charts'
+        title: 'Version Helm Charts'
         createGitHubReleases: false
       env:
         GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}

--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -6,6 +6,7 @@ on:
     - main
     paths:
     - charts/kubernetes-agent/**
+    - charts/hello-octo/**
     - .github/workflows/create-versioning-pr.yaml
     
 jobs:

--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -46,7 +46,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
 
-    - name: 'Update version and commit Chart.yaml'
+    - name: 'Update version and commit Chart.yaml for Kubernetes Agent'
       run: |
         version=$(jq -r .version charts/kubernetes-agent/package.json)
         version="$version" yq -i '.version = strenv(version)' charts/kubernetes-agent/Chart.yaml
@@ -56,6 +56,19 @@ jobs:
         git add charts/kubernetes-agent/Chart.yaml
         git add pnpm-lock.yaml
         git commit -m "Update charts/kubernetes-agent/Chart.yaml"
+        git push --set-upstream origin changeset-release/main
+      if: steps.changesets.outputs.hasChangesets == 'true'
+
+    - name: 'Update version and commit Chart.yaml for Hello Octo'
+      run: |
+        version=$(jq -r .version charts/hello-octo/package.json)
+        version="$version" yq -i '.version = strenv(version)' charts/hello-octo/Chart.yaml
+        pnpm i --lockfile-only
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git add charts/hello-octo/Chart.yaml
+        git add pnpm-lock.yaml
+        git commit -m "Update charts/hello-octo/Chart.yaml"
         git push --set-upstream origin changeset-release/main
       if: steps.changesets.outputs.hasChangesets == 'true'
 

--- a/.github/workflows/hello-octo-publish-chart.yaml
+++ b/.github/workflows/hello-octo-publish-chart.yaml
@@ -1,19 +1,19 @@
-name: Publish Kubernetes Agent chart
+name: Publish Hello Octo chart
 
 on:
   push:
     branches:
     - main
     paths:
-    - charts/kubernetes-agent/**
-    - .github/workflows/kubernetes-agent-publish-chart.yaml
+    - charts/hello-octo/**
+    - .github/workflows/hello-octo-publish-chart.yaml
 
   pull_request:
     branches:
     - '*'
     paths:
-    - charts/kubernetes-agent/**
-    - .github/workflows/kubernetes-agent-publish-chart.yaml
+    - charts/hello-octo/**
+    - .github/workflows/hello-octo-publish-chart.yaml
 
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
       uses: pietrobolcato/action-read-yaml@1.0.0
       id: read_chart_yaml
       with:
-        config: ${{ github.workspace }}/charts/kubernetes-agent/Chart.yaml
+        config: ${{ github.workspace }}/charts/hello-octo/Chart.yaml
 
     - name: Get branch names
       id: branch_names
@@ -56,16 +56,16 @@ jobs:
         full_version="$chart_version$pre_release"
 
         echo "CHART_VERSION=$full_version" >> $GITHUB_ENV
-        echo "PACKAGE_NAME=kubernetes-agent-$full_version.tgz" >> $GITHUB_OUTPUT
+        echo "PACKAGE_NAME=hello-octo-$full_version.tgz" >> $GITHUB_OUTPUT
 
     - name: Package Chart
-      run: helm package './charts/kubernetes-agent' --version '${{ env.CHART_VERSION }}'
+      run: helm package './charts/hello-octo' --version '${{ env.CHART_VERSION }}'
       
     - uses: actions/upload-artifact@v3
       name: Upload packaged chart
       with:
         name: '${{ steps.version.outputs.PACKAGE_NAME }}'
-        path: '${{ github.workspace }}/kubernetes-agent-${{ env.CHART_VERSION }}.tgz'
+        path: '${{ github.workspace }}/hello-octo-${{ env.CHART_VERSION }}.tgz'
   
   publish_artifactory:
     runs-on: ubuntu-latest    
@@ -104,10 +104,3 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: '${{ needs.version_and_package.outputs.PACKAGE_NAME }}'
-        
-    - name: Login to DockerHub
-      run: helm registry login registry-1.docker.io -u '${{ secrets.DOCKERHUB_USERNAME }}' -p '${{ secrets.DOCKERHUB_TOKEN }}'
-          
-    - name: Push Chart to DockerHub    
-      run: helm push '${{ needs.version_and_package.outputs.PACKAGE_NAME }}' oci://registry-1.docker.io/octopusdeploy
-      

--- a/charts/hello-octo/Chart.yaml
+++ b/charts/hello-octo/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: hello-octo
+description: A Helm chart for testing helm chart handling in Octopus Server
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "0.0.0"
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "alpine3.18-perl"
+
+

--- a/charts/hello-octo/README.md
+++ b/charts/hello-octo/README.md
@@ -1,0 +1,3 @@
+# Background
+
+This is a basic helm chart published in an OCI Registry used for tests in Calamari, Tentacle, and Octopus Deploy.

--- a/charts/hello-octo/package.json
+++ b/charts/hello-octo/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "hello-octo",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Test Helm Chart",
+    "author": "Octopus Deploy Ptd Ltd"
+  }

--- a/charts/hello-octo/templates/NOTES.txt
+++ b/charts/hello-octo/templates/NOTES.txt
@@ -1,0 +1,3 @@
+This helm chart is only used to test Octopus Server and it's tooling.
+
+It installs an unconfigured nginx container into a cluster.

--- a/charts/hello-octo/templates/hello-octo-deployment.yaml
+++ b/charts/hello-octo/templates/hello-octo-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-octo-deployment
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: hello-octo
+  template:
+    metadata:
+      labels:
+        app: hello-octo
+    spec:
+      containers:
+        - name: hello-octo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/hello-octo/values.yaml
+++ b/charts/hello-octo/values.yaml
@@ -1,0 +1,9 @@
+
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ importers:
         specifier: ^2.27.1
         version: 2.27.1
 
+  charts/hello-octo: {}
+
   charts/kubernetes-agent: {}
 
 packages:


### PR DESCRIPTION
This test helm chart will be used in tests needing a helm chart in an oci repository.

I've updated the versioning workflow to be more generic so it produces a commit with title "Version Helm Charts". I've also added a workflow for the new chart so it publishes to artifactory. It doesn't publish to docker as it's only for tests.