### PR TITLE
Add TaskCap parameter

### DIFF
--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -83,6 +83,8 @@ spec:
                   {{- end}}
                   - name: ADMIN_EMAIL
                     value: {{.Values.octopus.email}}
+                  - name: TASK_CAP
+                    value: {{.Values.octopus.taskCap}}
                   {{- if .Values.octopus.licenseKeyBase64 }}
                   - name: OCTOPUS_SERVER_BASE64_LICENSE
                     # Your license key goes here. When using more than one node, a HA license is required.

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
                   - name: ADMIN_EMAIL
                     value: {{.Values.octopus.email}}
                   - name: TASK_CAP
-                    value: {{.Values.octopus.taskCap}}
+                    value: !!str {{.Values.octopus.taskCap}}
                   {{- if .Values.octopus.licenseKeyBase64 }}
                   - name: OCTOPUS_SERVER_BASE64_LICENSE
                     # Your license key goes here. When using more than one node, a HA license is required.

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -19,6 +19,9 @@ octopus:
   # The Octopus admin email
   email:
 
+  # The task cap to set for the new node. If blank the default of 5 is used.
+  taskCap:
+
   # The Octopus server image. 
   # Visit https://hub.docker.com/r/octopusdeploy/octopusdeploy for the available versions.
   image:


### PR DESCRIPTION
Tested by deploying chart to AKS with and without the parameter in the `values.yaml`

Enabled the feature introduced by https://github.com/OctopusDeploy/Issues/issues/8672