### PR TITLE
Disable lookupcache so Tentacle can discover new files without a long delay

### DIFF
--- a/.changeset/spicy-flies-raise.md
+++ b/.changeset/spicy-flies-raise.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Disable lookupcache so Tentacle can discover new files without a long delay

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -14,7 +14,7 @@ spec:
   storageClassName: {{ include "nfs.storageClassName" . }}
   mountOptions:
     - nfsvers=4.1
-    - noac
+    - lookupcache=none
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: {{ printf "%s/octopus##" (include "nfs.serverAddress" .)}}

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -14,6 +14,7 @@ spec:
   storageClassName: {{ include "nfs.storageClassName" . }}
   mountOptions:
     - nfsvers=4.1
+    - noac
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: {{ printf "%s/octopus##" (include "nfs.serverAddress" .)}}


### PR DESCRIPTION
[sc-71110]

As part of performance testing, we found that the [NFS attributing caching](https://man7.org/linux/man-pages/man5/nfs.5.html) was slowing down new file discovery by ~30s (when we try to read a new log file) due to caching directory attributes.

This PR sets `lookupcache=none` so file creation and removal are quickly discovered.

From https://man7.org/linux/man-pages/man5/nfs.5.html
```
lookupcache=mode
Specifies how the kernel manages its cache of directory entries for a given mount point. mode can be one of all, none, pos, or positive. This option is supported in kernels 2.6.28 and later.

The Linux NFS client caches the result of all NFS LOOKUP requests. If the requested directory entry exists on the server, the result is referred to as positive. If the requested directory entry does not exist on the server, the result is referred to as negative.

If this option is not specified, or if all is specified, the client assumes both types of directory cache entries are valid until their parent directory's cached attributes expire.

If pos or positive is specified, the client assumes positive entries are valid until their parent directory's cached attributes expire, but always revalidates negative entires before an application can use them.

If none is specified, the client revalidates both types of directory cache entries before an application can use them. This permits quick detection of files that were created or removed by other clients, but can impact application and server performance.

The DATA AND METADATA COHERENCE section contains a detailed discussion of these trade-offs.
```