### PR TITLE
change nfs deployment to stateful set

### DIFF
--- a/.changeset/little-tables-collect.md
+++ b/.changeset/little-tables-collect.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Change the nfs deployment to be a stateful set because it makes more sense considering only one nfs pod can be run at a time.

--- a/charts/kubernetes-agent/templates/nfs-service.yaml
+++ b/charts/kubernetes-agent/templates/nfs-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "nfs.name" .}}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  clusterIP: None
   selector:
     app.kubernetes.io/name: {{ include "nfs.name" .}}
   ports:

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.persistence.nfs.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "nfs.name" .}}
   namespace: {{ .Release.Namespace | quote }}
@@ -50,5 +50,4 @@ spec:
             claimName: {{ include "nfs.podPvcName" . }}
       nodeSelector:
         kubernetes.io/os: "linux"
-
 {{- end -}}


### PR DESCRIPTION
A stateful set makes more sense for the nfs server as we can only have a single instance (pod) of it at one time.

This has the added benefit of allowing us to use a [headless service](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id) now.

[Slack thread ](https://octopusdeploy.slack.com/archives/C05KK1G85J5/p1711340316630159)