### PR TITLE
Use NFS mount timeout instead of getting the nfs pod to wait for connections to close before shutting down

### DIFF
--- a/.changeset/gold-bugs-tickle.md
+++ b/.changeset/gold-bugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Make pods that mount NFS timeout when trying to access an invalid NFS mount rather than making the NFS pod wait for all connections to close before shutting down.

--- a/charts/kubernetes-agent/templates/nfs-deployment.yaml
+++ b/charts/kubernetes-agent/templates/nfs-deployment.yaml
@@ -27,20 +27,6 @@ spec:
         - name: {{ include "nfs.name" .}}
           image: "{{ .Values.persistence.nfs.image.repository }}:{{ .Values.persistence.nfs.image.tag }}"
           imagePullPolicy: {{ .Values.persistence.nfs.image.pullPolicy }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/bash
-                  - '-c'
-                  - >-
-                    echo "Prestop: Delaying shutdown until NFS connections are
-                    closed" > /proc/1/fd/1;  counter=0;  nfsConnection=$(netstat
-                    | grep :nfs); while [[ $nfsConnection ]]; do 
-                    counter=$((++counter)); nfsConnection=$(netstat | grep
-                    :nfs);  echo "Waiting for NFS connections to close -
-                    ${counter}s" > /proc/1/fd/1; sleep 1;  done;  echo "Prestop:
-                    All NFS connections are closed" > /proc/1/fd/1;
           securityContext:
             privileged: true
           resources:

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -16,8 +16,8 @@ spec:
     - nfsvers=4.1
     - lookupcache=none
     - soft
-    - timeo=5
-    - retrans=5
+    - timeo=50
+    - retrans=4
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: {{ printf "%s/octopus##" (include "nfs.serverAddress" .)}}

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -16,7 +16,6 @@ spec:
     - nfsvers=4.1
     - lookupcache=none
     - soft
-    - bg
     - timeo=5
     - retrans=5
   csi:

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -18,6 +18,7 @@ spec:
     - soft
     - bg
     - timeo=5
+    - retrans=5
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: {{ printf "%s/octopus##" (include "nfs.serverAddress" .)}}

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -15,6 +15,9 @@ spec:
   mountOptions:
     - nfsvers=4.1
     - lookupcache=none
+    - soft
+    - bg
+    - timeo=5
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: {{ printf "%s/octopus##" (include "nfs.serverAddress" .)}}


### PR DESCRIPTION
# Background

When we add support to use the default storage class as the basis for the nfs pod (https://github.com/OctopusDeploy/helm-charts/pull/99), trying to access a broken nfs mount on tentacle hangs instead of just failing with a stale file handle. To fix this, we can use these additional options on the nfs mount. This makes the operation fail if it fails after a specific number of retries.

# Details

soft:
<img width="898" alt="Screenshot 2024-04-03 at 11 48 15" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/4c164dcf-dfbc-4f51-afb0-13a1a7203487">

Basically, if we don't have soft, it will never "fail" and will just hang forever trying to reconnect.

**Note:** In terms of soft causing data corruption, I think if we say that "if file access fails once on a pod (tentacle or script pod) we will restart the tentacle deployment and fail the scripts in question" then we shouldn't have an issue with data corruption.

timeo:
<img width="887" alt="Screenshot 2024-04-03 at 11 48 23" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/7d19d6f3-5826-4eeb-83fc-4a1c741e91f1">

how long it waits before failing a connection in tenths of a second. The standard is 60 seconds.

retrans:
<img width="864" alt="Screenshot 2024-04-03 at 11 48 29" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/40a2782a-c111-4a72-a9dd-67bf3a118612">

how many times it will retry before failing.

# Testing

With the settings I have now (`soft, timeo=5, retrans=5`) I get the following output in manual testing:
<img width="425" alt="Screenshot 2024-04-03 at 11 47 42" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/0956d544-46cc-4a9d-aa27-1c8cdccb8cfe">

I've done more tests where I saw it take up to 11.5 seconds to fail too so the range is roughly 3-12 seconds for accessing a broken mount to fail. If you start the nfs pod back on the same node, the mount becomes valid again and returns the `ls` command instantly.

# Testing update

I've adjusted the numbers to `timeo=50, retrans=4`. This gives each connection time to recover (~5 seconds) and in total it takes between 25 and 50 seconds approximately.

<img width="480" alt="Screenshot 2024-04-03 at 15 26 44" src="https://github.com/OctopusDeploy/helm-charts/assets/97430840/0d516b1b-3a89-4fcd-8804-5931aafad3f5">