### PR TITLE
Update Tentacle to 8.1.1249

### DIFF
--- a/.changeset/silver-cooks-notice.md
+++ b/.changeset/silver-cooks-notice.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update Tentacle to 8.1.1249 with breaking services change

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.6.3"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1079"
+appVersion: "8.1.1249"


### PR DESCRIPTION
Updates the Tentacle 8.1.1249 which contains the breaking service contract changes in https://github.com/OctopusDeploy/OctopusTentacle/pull/859

This should only be merged once the TentacleClient changes https://github.com/OctopusDeploy/OctopusDeploy/pull/23677 are merged.