### PR TITLE
Added PDB to script pods

### DIFF
--- a/.changeset/sweet-eyes-reply.md
+++ b/.changeset/sweet-eyes-reply.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Added PDB to script pods to prevent accidental failure of tasks whilst draining nodes

--- a/charts/kubernetes-agent/templates/script-pdb.yaml
+++ b/charts/kubernetes-agent/templates/script-pdb.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.scriptPodDisruptionBudgetEnabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: script-pod-disruption-budget
+  namespace: {{ .Release.Namespace }}
+spec:
+  maxUnavailable: 0
+  selector:
+    matchExpressions:
+    - { key: octopus.com/scriptTicketId, operator: Exists }
+{{- end }}

--- a/charts/kubernetes-agent/tests/script-pdb_test.yaml
+++ b/charts/kubernetes-agent/tests/script-pdb_test.yaml
@@ -1,0 +1,33 @@
+suite: "podDisruptionBudget"
+templates:
+  - templates/script-pdb.yaml
+tests:
+  - it: "is not created when script PDB is disabled"
+    set:
+      scriptPodDisruptionBudgetEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "is created when script PDB is enabled"
+    set:
+      scriptPodDisruptionBudgetEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: metadata.name
+          value: script-pod-disruption-budget
+      - equal: 
+          path: spec.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.selector.matchExpressions[0].key
+          value: octopus.com/scriptTicketId
+      - equal: 
+          path: spec.selector.matchExpressions[0].operator
+          value: Exists

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -45,6 +45,8 @@ persistence:
     volumeName: ""
     storageClassName: ""
 
+scriptPodDisruptionBudgetEnabled: true
+
 imagePullSecrets: []
 nameOverride: ""
 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -61,7 +61,7 @@ podServiceAccount:
   # Annotations to add to the service account
   annotations: {}
 
-  # Specifies that the pod service account should be contrained to target namespaces
+  # Specifies that the pod service account should be constrained to target namespaces
   # An empty array indicates a cluster role binding (Default)
   targetNamespaces: []
 


### PR DESCRIPTION
This PR adds a PDB to the deployment namespace for the Kubernetes Agent. This attempts to stop script pods from being evicted accidentally during cluster maintenance. Since the script pods are generally short-lived, this shouldn't be an issue for cluster administrators.

To disable this behaviour, you can set the value `scriptPodDisruptionBudgetEnabled` to `false`.

## Testing
I created a deployment mirroring a script pod we create, then cordoned and attempted to drain a node with a script pod:
```
❯ k drain kind-worker3 --ignore-daemonsets=true --timeout=5m --force=true
Warning: ignoring DaemonSet-managed Pods: kube-system/kindnet-rvsfz, kube-system/kube-proxy-jg2jc; deleting Pods that declare no controller: octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
evicting pod octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
error when evicting pods/"octopus-script-obdjvaszxewz1k8esaaza" -n "octopus-agent-microk8s" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```

when draining and emulating the pod being finished (by terminating the pod), the drain finishes:
```
❯ k drain kind-worker3 --ignore-daemonsets=true --timeout=5m --force=true
node/kind-worker3 already cordoned
Warning: ignoring DaemonSet-managed Pods: kube-system/kindnet-rvsfz, kube-system/kube-proxy-jg2jc; deleting Pods that declare no controller: octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
evicting pod octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
error when evicting pods/"octopus-script-obdjvaszxewz1k8esaaza" -n "octopus-agent-microk8s" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
error when evicting pods/"octopus-script-obdjvaszxewz1k8esaaza" -n "octopus-agent-microk8s" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
error when evicting pods/"octopus-script-obdjvaszxewz1k8esaaza" -n "octopus-agent-microk8s" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
=== deleted pod manually here ===
evicting pod octopus-agent-microk8s/octopus-script-obdjvaszxewz1k8esaaza
node/kind-worker3 drained
```

Note: 
Creating the PDB caused the k8s server to emit the following event:
```
Warning   UnmanagedPods   
poddisruptionbudget/script-pod-disruption-budget   
Pods selected by this PodDisruptionBudget (selector: &LabelSelector{MatchLabels:map[string]string{},MatchExpressions:[]LabelSelectorRequirement{LabelSelectorRequirement{Key:octopus.com/scriptTicketId,Operator:Exists,Values:[],},},}) were found to be unmanaged. As a result, the status of the PDB cannot be calculated correctly, which may result in undefined behavior. To account for these pods please set ".spec.minAvailable" field of the PDB to an integer value.
```
This isn't actually an issue here, but some adding a note in case anyone sees it and gets concerned!