### PR TITLE
Read Pod logs from the K8s API

### DIFF
--- a/.changeset/witty-houses-punch.md
+++ b/.changeset/witty-houses-punch.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Give Tentacle permissions to read Pod logs

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.7.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1249"
+appVersion: "8.1.1272"

--- a/charts/kubernetes-agent/templates/tentacle-role.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-role.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: ["*"]
-  resources: ["pods", "configmaps", "secrets"]
+  resources: ["pods", "pods/log", "configmaps", "secrets"]
   verbs: ["*"]


### PR DESCRIPTION
[sc-71685]

This PR updates the Tentacle version to start reading Pod logs from the K8s API. As part of this, we also need to set the appropriate permissions for Tentacle.