### PR TITLE
Pass pod PVC name, not volume JSON to tentacle container

### DIFF
--- a/.changeset/quick-gifts-type.md
+++ b/.changeset/quick-gifts-type.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Pass pod PVC name, not JSON

--- a/.changeset/quick-gifts-type.md
+++ b/.changeset/quick-gifts-type.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": patch
 ---
 
-Pass pod PVC name, not JSON
+Pass pod PVC name, not JSON. Also bump Tentacle to support this.

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: "0.7.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1272"
+appVersion: "8.1.1302"

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -89,13 +89,3 @@ The name of the PersistentVolumeClaim to configure
 {{- printf "%s-pvc" (include "kubernetes-agent.fullName" .) }}
 {{- end }}
 {{- end }}
-
-{{/*
-This is passed to the Tentacle Container as JSON
-*/}}
-{{- define "kubernetes-agent.podVolumeYaml" -}}
-volumes:
-- name: tentacle-home
-  persistentVolumeClaim:
-    claimName: {{ include "kubernetes-agent.pvcName" . }}
-{{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -64,10 +64,8 @@ spec:
               value: {{ .Release.Namespace | quote }}
             - name: "OCTOPUS__K8STENTACLE__PODSERVICEACCOUNTNAME"
               value: {{ include "kubernetes-agent.podServiceAccountName" . | quote }}
-            - name: "OCTOPUS__K8STENTACLE__PODVOLUMEJSON"
-              value: {{ (include "kubernetes-agent.podVolumeYaml" . | fromYaml).volumes  | toJson  | quote}}
-            - name: "OCTOPUS__K8STENTACLE__FORCE"
-              value: "True"
+            - name: "OCTOPUS__K8STENTACLE__PODVOLUMECLAIMNAME"
+              value: {{ (include "kubernetes-agent.pvcName" .)  | quote}}
             - name: "OCTOPUS__K8STENTACLE__HELMRELEASENAME"
               value: {{ .Release.Name | quote}}
             - name: "OCTOPUS__K8STENTACLE__HELMCHARTVERSION"


### PR DESCRIPTION
We now pass pod PVC name to Tentacle container, not the JSON serialized volume configuration

Tentacle change: https://github.com/OctopusDeploy/OctopusTentacle/pull/876

NOTE: This PR will need to be updated with the Tentacle app version that has this change (so they go in together)