### PR TITLE
Support providing test data to ConfigMap

### DIFF
--- a/.changeset/strange-mugs-glow.md
+++ b/.changeset/strange-mugs-glow.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Support providing test data to ConfigMap

--- a/charts/kubernetes-agent/templates/tentacle-configmap.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-configmap.yaml
@@ -3,3 +3,7 @@ kind: ConfigMap
 metadata:
   name: tentacle-config
   namespace: {{ .Release.Namespace | quote }}
+{{- with .Values.testing.tentacle.configMap.data }}
+data:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}

--- a/charts/kubernetes-agent/tests/tentacle-configmap_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-configmap_test.yaml
@@ -1,0 +1,24 @@
+suite: "tentacle configuration"
+templates:
+  - templates/tentacle-configmap.yaml
+tests:
+  - it: "defaults to empty data (no data field)"
+    asserts:
+      - notExists:
+          path: data
+
+  - it: "when testing data is provided, populates the data field"
+    set:
+      testing:
+        tentacle:
+          configMap:
+            data:
+              key.1: "value 1"
+              key.2: 123
+    asserts:
+      - equal:
+          path: data["key.1"]
+          value: "value 1"
+      - equal:
+          path: data["key.2"]
+          value: 123

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -99,6 +99,7 @@ resources: {}
 #   memory: 128Mi
 
 
+# Used for integration testing to avoid registring with a real Octopus Server
 testing:
   tentacle:
     configMap:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -97,3 +97,9 @@ resources: {}
 # requests:
 #   cpu: 100m
 #   memory: 128Mi
+
+
+testing:
+  tentacle:
+    configMap:
+      data: {}


### PR DESCRIPTION
In the Tentacle integration tests, we need a way to pre-provide config map data, so Tentacle doesn't try and register itself with a server that doesn't exist