### PR TITLE
Add NFS Watchdog to helm chart

### DIFF
--- a/.changeset/cool-rats-deny.md
+++ b/.changeset/cool-rats-deny.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Added an NFS watchdog to remove pods should the NFS mount become stale

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -66,6 +66,13 @@ Create the name of the pod cluster role to use
 {{- end }}
 
 {{/*
+Create the name of the pod cluster role for deleting pods
+*/}}
+{{- define "kubernetes-agent.podDeleterClusterRoleName" -}}
+{{- printf "%s-delete-role" (include "kubernetes-agent.podServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
 Create the name of the pod cluster role binding to use
 */}}
 {{- define "kubernetes-agent.podClusterRoleBindingName" -}}

--- a/charts/kubernetes-agent/templates/pod-clusterroles.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterroles.yaml
@@ -17,3 +17,18 @@ rules:
   verbs:
   - '*'
 {{- end }}
+{{- if and .Values.persistence.nfs.watchdog.enabled .Values.persistence.nfs.enabled}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubernetes-agent.podDeleterClusterRoleName" . }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - 'pods'
+    verbs:
+      - 'delete'
+      - 'list'
+{{- end }}

--- a/charts/kubernetes-agent/templates/pod-rolebinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebinding.yaml
@@ -18,3 +18,17 @@ roleRef:
   name: {{ $podClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-binding" $podServiceAccountFullName }}
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $podServiceAccountName }}
+    namespace: {{ $.Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $podClusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubernetes-agent/templates/pod-rolebinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebinding.yaml
@@ -18,7 +18,6 @@ roleRef:
   name: {{ $podClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
-# Only create the role binding for the watchdog if NFS and the Watchdog are enabled
 {{- if and .Values.persistence.nfs.watchdog.enabled .Values.persistence.nfs.enabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubernetes-agent/templates/pod-rolebinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebinding.yaml
@@ -18,6 +18,8 @@ roleRef:
   name: {{ $podClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
+# Only create the role binding for the watchdog if NFS and the Watchdog are enabled
+{{- if and .Values.persistence.nfs.watchdog.enabled .Values.persistence.nfs.enabled}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -32,3 +34,4 @@ roleRef:
   kind: ClusterRole
   name: {{ $podClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/kubernetes-agent/templates/pod-rolebindings.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebindings.yaml
@@ -1,6 +1,7 @@
 {{- $podServiceAccountName := include "kubernetes-agent.podServiceAccountName" . -}}
 {{- $podServiceAccountFullName := include "kubernetes-agent.podServiceAccountFullName" . -}}
 {{- $podClusterRoleName := include "kubernetes-agent.podClusterRoleName" . -}}
+{{- $podDeleterClusterRoleName := include "kubernetes-agent.podDeleterClusterRoleName" . -}}  
 
 {{- range $targetNamespace := $.Values.podServiceAccount.targetNamespaces }}
 ---
@@ -23,7 +24,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ printf "%s-binding" $podServiceAccountFullName }}
+  name: {{ printf "%s-deleter-binding" $podServiceAccountFullName }}
   namespace: {{ .Release.Namespace | quote }}
 subjects:
   - kind: ServiceAccount
@@ -31,6 +32,6 @@ subjects:
     namespace: {{ $.Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
-  name: {{ $podClusterRoleName }}
+  name: {{ $podDeleterClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ .Chart.Version | quote}}
             - name: "OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP"
               value: {{ .Values.tentacle.debug.disableAutoPodCleanup | quote }}
+            {{- if and .Values.persistence.nfs.watchdog.enabled .Values.persistence.nfs.enabled}}
+            - name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
+              value: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
+            {{- end }}
             - name: "OCTOPUS__TENTACLE__LOGLEVEL"
               value: {{ .Values.tentacle.logLevel | default "Debug" }}
             - name: "TentacleHome"
@@ -103,6 +107,29 @@ spec:
           volumeMounts:
             - mountPath: /octopus
               name: tentacle-home
+        {{- if and .Values.persistence.nfs.watchdog.enabled .Values.persistence.nfs.enabled}}
+        - name: nfs-watchdog
+          image: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
+          imagePullPolicy: {{ .Values.persistence.nfs.watchdog.image.pullPolicy }}
+          env:
+            - name: "watchdog_directory"
+              value: "/octopus"
+            {{ if .Values.persistence.nfs.watchdog.loop_seconds }}
+            - name: "watchdog_loop_seconds"
+              value: "{{ .Values.persistence.nfs.watchdog.loop_seconds }}"
+            {{ end }}
+            {{ if .Values.persistence.nfs.watchdog.initial_backoff_seconds }}
+            - name: "watchdog_initial_backoff_seconds"
+              value: "{{ .Values.persistence.nfs.watchdog.initial_backoff_seconds }}"
+            {{ end }}
+            {{ if .Values.persistence.nfs.watchdog.timeout_seconds }}
+            - name: "watchdog_timeout_seconds"
+              value: "{{ .Values.persistence.nfs.watchdog.timeout_seconds }}"
+            {{ end }}
+          volumeMounts:
+            - mountPath: /octopus
+              name: tentacle-home
+        {{- end}}
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-clusterole_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-clusterole_test.yaml.snap
@@ -15,3 +15,16 @@ should match snapshot:
           - '*'
         verbs:
           - '*'
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: octopus-agent-pod-RELEASE-NAME-delete-role
+    rules:
+      - apiGroups:
+          - '*'
+        resources:
+          - pods
+        verbs:
+          - delete
+          - list

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-rolebinding_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-rolebinding_test.yaml.snap
@@ -13,3 +13,17 @@ matches snapshot with one target namespace:
       - kind: ServiceAccount
         name: octopus-agent-pod
         namespace: NAMESPACE
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: octopus-agent-pod-RELEASE-NAME-binding
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: octopus-agent-pod-RELEASE-NAME-role
+    subjects:
+      - kind: ServiceAccount
+        name: octopus-agent-pod
+        namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-rolebinding_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-rolebinding_test.yaml.snap
@@ -17,12 +17,12 @@ matches snapshot with one target namespace:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: octopus-agent-pod-RELEASE-NAME-binding
+      name: octopus-agent-pod-RELEASE-NAME-deleter-binding
       namespace: NAMESPACE
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: octopus-agent-pod-RELEASE-NAME-role
+      name: octopus-agent-pod-RELEASE-NAME-delete-role
     subjects:
       - kind: ServiceAccount
         name: octopus-agent-pod

--- a/charts/kubernetes-agent/tests/pod-clusterole_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-clusterole_test.yaml
@@ -1,6 +1,6 @@
 suite: "pod permissions"
 templates:
-- templates/pod-clusterrole.yaml
+- templates/pod-clusterroles.yaml
 tests:
 - it: "cluster role can have rules overridden"
   set:
@@ -12,13 +12,22 @@ tests:
           resources: ["pods"]
           verbs: ["get", "watch", "list"]
   asserts:
-  - contains:
-      path: rules
-      content:
-        apiGroups:
-        - '*'
-        resources: ["pods"]
-        verbs: ["get", "watch", "list"]
+    - contains:
+        path: rules
+        content:
+          apiGroups:
+          - '*'
+          resources: ["pods"]
+          verbs: ["get", "watch", "list"]
+      documentIndex: 0
+    - contains: 
+        path: rules
+        content:
+          apiGroups:
+          - '*'
+          resources: ["pods"]
+          verbs: ["delete", "list"]
+      documentIndex: 1
 
 - it: "should match snapshot"
   asserts:

--- a/charts/kubernetes-agent/tests/pod-rolebinding_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-rolebinding_test.yaml
@@ -8,7 +8,7 @@ tests:
       targetNamespaces: ["ns-1", "ns-2", "ns-3"]
   asserts:
   - hasDocuments:
-      count: 3
+      count: 4
 
 - it: "matches snapshot with one target namespace"
   set:
@@ -17,15 +17,31 @@ tests:
   asserts:
   - matchSnapshot: {}
 
-- it: "is not created when target namespaces is empty"
+- it: "only creates the default rolebinding when target namespaces is empty"
   set:
     podServiceAccount:
       targetNamespaces: []
   asserts:
   - hasDocuments:
-      count: 0
+      count: 1
+  - equal: 
+        path: metadata.namespace
+        value: NAMESPACE
 
-- it: "is not created by default"
+- it: "only creates the default rolebinding by default"
   asserts:
   - hasDocuments:
-      count: 0
+      count: 1
+  - equal:
+      path: metadata.namespace
+      value: NAMESPACE
+
+- it: "is not created when watchdog is disabled"
+  set:
+    persistence:
+      nfs:
+        watchdog:
+          enabled: false
+  asserts:
+    - hasDocuments:
+        count: 0

--- a/charts/kubernetes-agent/tests/pod-rolebinding_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-rolebinding_test.yaml
@@ -1,6 +1,6 @@
 suite: "pod permissions"
 templates:
-- templates/pod-rolebinding.yaml
+- templates/pod-rolebindings.yaml
 tests:
 - it: "creates a role binding per target namespace"
   set:

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -1,0 +1,98 @@
+suite: "tentacle deployment"
+templates:
+  - templates/tentacle-deployment.yaml
+tests:
+  - it: "includes the watchdog when NFS and Watchdog are both enabled"
+    set:
+      persistence:
+        nfs:
+          enabled: true
+          watchdog:
+            enabled: true
+            image:
+              repository: octopusdeploy/kubernetes-agent-nfs-watchdog
+              tag: "0.0.1"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: 
+            name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
+            value: "octopusdeploy/kubernetes-agent-nfs-watchdog:0.0.1"
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: nfs-watchdog
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "octopusdeploy/kubernetes-agent-nfs-watchdog:0.0.1"
+
+  - it: "Doesn't include the watchdog when only the Watchdog is enabled"
+    set:
+      persistence:
+        nfs:
+          enabled: false
+          watchdog:
+            enabled: true
+            image:
+              repository: octopusdeploy/kubernetes-agent-nfs-watchdog
+              tag: "0.0.1"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
+          any: true
+      - notContains: 
+          path: spec.template.spec.containers
+          content:
+            name: "nfs-watchdog"
+          any: true
+
+  - it: "Doesn't include the watchdog when watchdog is disabled"
+    set:
+      persistence:
+        nfs:
+          enabled: true
+          watchdog:
+            enabled: false
+            image:
+              repository: octopusdeploy/kubernetes-agent-nfs-watchdog
+              tag: "0.0.1"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
+          any: true
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: "nfs-watchdog"
+          any: true

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -48,7 +48,7 @@ persistence:
       image:
         repository: octopusdeploy/kubernetes-agent-nfs-watchdog
         pullPolicy: IfNotPresent
-        tag: "0.0.1"
+        tag: "0.0.2"
 
   claim:
     size: 1Gi

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -40,6 +40,16 @@ persistence:
       pullPolicy: IfNotPresent
       tag: "1.0.1"
 
+    watchdog:
+      enabled: true
+      loop_seconds: ""
+      initial_backoff_seconds: ""
+      timeout_seconds: ""
+      image:
+        repository: octopusdeploy/kubernetes-agent-nfs-watchdog
+        pullPolicy: IfNotPresent
+        tag: "0.0.1"
+
   claim:
     size: 1Gi
     volumeName: ""


### PR DESCRIPTION
This PR adds the NFS Watchdog to the helm chart, along with associated tests. This also makes it so that the cluster rolebinding for pods is added to the release namespace by default when NFS is enabled, as we need DELETE access to pods in this namespace for the NFS watchdog to function.