### PR TITLE
Remove ability to change replica count

### DIFF
--- a/.changeset/friendly-jars-cheer.md
+++ b/.changeset/friendly-jars-cheer.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Remove ability to change replica count

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "nfs.name" .}}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ include "nfs.name" .}}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kubernetes-agent.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "kubernetes-agent.selectorLabels" . | nindent 6 }}

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -1,8 +1,4 @@
 # Default values for kubernetes-agent.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
 
 image:
   repository: octopusdeploy/kubernetes-tentacle


### PR DESCRIPTION
We don't currently support multiple replicas of the Tentacle container, so let's remove the option to change it