### PR TITLE
Increase default nfs volume and claim size

### DIFF
--- a/.changeset/eight-wasps-relate.md
+++ b/.changeset/eight-wasps-relate.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Increased the default NFS volume size to 10Gi from 1Gi

--- a/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
@@ -41,5 +41,5 @@ should match snapshot:
           terminationGracePeriodSeconds: 30
           volumes:
             - emptyDir:
-                sizeLimit: 1Gi
+                sizeLimit: 10Gi
               name: octopus-volume

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -29,7 +29,7 @@ persistence:
     # Change to false if the NFS container should not be used
     enabled: true
     
-    size: 1Gi
+    size: 10Gi
     image:
       repository: octopusdeploy/nfs-server
       pullPolicy: IfNotPresent
@@ -46,7 +46,7 @@ persistence:
         tag: "0.0.2"
 
   claim:
-    size: 1Gi
+    size: 10Gi
     volumeName: ""
     storageClassName: ""
 


### PR DESCRIPTION
# Background
[SC-73899]
When the NFS pod runs out of space it will restart and causes all of the data in the `/octopus` directory to be lost

# Result 
- Increased the default size of the `emptyDir` volume used by the NFS pod to `10Gi`
- Increased the default size of the PVC used by the tentacle pod to `10Gi` 