### PR TITLE
Space checks for tentacle

### DIFF
--- a/.changeset/unlucky-days-breathe.md
+++ b/.changeset/unlucky-days-breathe.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update to add required PERSISTENTVOLUMESIZE variable

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -102,6 +102,12 @@ spec:
             - name: "ListeningPort"
               value: {{ .Values.tentacle.listeningPort | quote }}
             {{- end }}
+            - name: "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE"
+              {{- if .Values.persistence.nfs.enabled }}
+              value: {{ .Values.persistence.nfs.size | quote }}
+              {{- else }}
+              value: {{ .Values.persistence.claim.size | quote }}
+              {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -77,7 +77,7 @@ spec:
               value: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
             {{- end }}
             - name: "OCTOPUS__TENTACLE__LOGLEVEL"
-              value: {{ .Values.tentacle.logLevel | default "Debug" }}
+              value: {{ .Values.tentacle.logLevel }}
             - name: "TentacleHome"
               value: "/octopus"
             - name: "TentacleApplications"

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -96,3 +96,48 @@ tests:
           content:
             name: "nfs-watchdog"
           any: true
+
+  - it: "Sets the PERSISTENTVOLUMESIZE variable to the correct setting when using NFS"
+    set:
+      persistence:
+        nfs:
+          enabled: true
+          size: 100Gi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE"
+            value: "100Gi"
+
+  - it: "Sets the PERSISTENTVOLUMESIZE variable to the correct setting when using Custom PVC"
+    set:
+      persistence:
+        nfs:
+          enabled: false
+        claim:
+          size: 101Gi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE"
+            value: "101Gi"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -17,7 +17,7 @@ tentacle:
   targetEnvironments: []
   targetRoles: []
   listeningPort: ""
-  logLevel: ""
+  logLevel: "Info"
   defaultNamespace: ""
   pollingConnectionCount: 5
 


### PR DESCRIPTION
When running Octopus Tentacle in the Kubernetes Agent, we can't reliably get disk space on the mounted volume using native disk space tools. This is because in some cases (especially using the default NFS implementation), the volume is actually an NFS export of a folder on the node. This means that disk space tools (like `df`) show the disk space free on the _node_ rather than the disk space that we've configured in Kubernetes to be available. When we exceed the disk space we've configured in Kubernetes, `kubelet` will evict the NFS pod.

This PR adds an environment variable to support [changes in Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/pull/904) to use `du` to check free disk space.

In addition, this pulls the logging back from `debug` to `info`, since there's some extra logging in the Tentacle changes, which we don't want to mess around with much.