### PR TITLE
Tighten affinity to ensure nfs and tentacle pods are only scheduled on linux/amd64 and linux/arm64 nodes

### DIFF
--- a/.changeset/orange-frogs-visit.md
+++ b/.changeset/orange-frogs-visit.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Tighten affinity rules for NFS and tentacle pods to only run on linux/amd64 and linux/arm64 nodes

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -7,4 +7,4 @@ version: "1.0.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1494"
+appVersion: "8.1.1507"

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -51,6 +51,18 @@ spec:
         - name: octopus-volume
           emptyDir:
             sizeLimit: {{ .Values.persistence.size}}
-      nodeSelector:
-        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - arm64
+                    - amd64
 {{- end -}}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -118,8 +118,20 @@ spec:
             - mountPath: /octopus
               name: tentacle-home
         {{- end}}
-      nodeSelector:
-        kubernetes.io/os: "linux"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - arm64
+                    - amd64
       volumes:
         - name: tentacle-home
           persistentVolumeClaim:

--- a/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
@@ -16,6 +16,20 @@ should match snapshot:
           labels:
             app.kubernetes.io/name: octopus-agent-nfs
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                          - linux
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                          - arm64
+                          - amd64
           containers:
             - env:
                 - name: SHARED_DIRECTORY
@@ -36,8 +50,6 @@ should match snapshot:
               volumeMounts:
                 - mountPath: /octopus
                   name: octopus-volume
-          nodeSelector:
-            kubernetes.io/os: linux
           terminationGracePeriodSeconds: 30
           volumes:
             - emptyDir:

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1494
+        app.kubernetes.io/version: 8.1.1507
         helm.sh/chart: kubernetes-agent-1.0.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1494
+        app.kubernetes.io/version: 8.1.1507
         helm.sh/chart: kubernetes-agent-1.0.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1494
+            app.kubernetes.io/version: 8.1.1507
             helm.sh/chart: kubernetes-agent-1.0.0
         spec:
           affinity:
@@ -82,7 +82,7 @@ should match snapshot:
                   value: "5"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-tentacle:8.1.1494
+              image: octopusdeploy/kubernetes-tentacle:8.1.1507
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -26,6 +26,20 @@ should match snapshot:
             app.kubernetes.io/version: 8.1.1494
             helm.sh/chart: kubernetes-agent-1.0.0
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                          - linux
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                          - arm64
+                          - amd64
           containers:
             - env:
                 - name: ACCEPT_EULA
@@ -87,8 +101,6 @@ should match snapshot:
               volumeMounts:
                 - mountPath: /octopus
                   name: tentacle-home
-          nodeSelector:
-            kubernetes.io/os: linux
           serviceAccountName: octopus-agent-tentacle
           volumes:
             - name: tentacle-home

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1494
+        app.kubernetes.io/version: 8.1.1507
         helm.sh/chart: kubernetes-agent-1.0.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1494
+        app.kubernetes.io/version: 8.1.1507
         helm.sh/chart: kubernetes-agent-1.0.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -21,7 +21,7 @@ agent:
     repository: octopusdeploy/kubernetes-tentacle
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "8.1.1494"
+    tag: "8.1.1507"
    
   serviceAccount:
     # The name of the service account to use.


### PR DESCRIPTION
If a user has any nodes that are running linux with a 32 bit or other architecture, this change will make sure that kubernetes doesn't try to schedule nfs and tentacle pods on those nodes as we only have container images for linux/amd64 and linux/arm64.

A related change is being made in Tentacle so that kubernetes won't schedule script pods on nodes with invalid architectures: https://github.com/OctopusDeploy/OctopusTentacle/pull/908