### PR TITLE
Add machine policy option to values

### DIFF
--- a/.changeset/green-parents-change.md
+++ b/.changeset/green-parents-change.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Allow users to specify custom machine policy

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -46,6 +46,10 @@ spec:
               value: {{ join "," .Values.agent.targetEnvironments | quote }}
             - name: "TargetRole"
               value: {{ join "," .Values.agent.targetRoles | quote }}
+            {{- with .Values.agent.machinePolicy }}
+            - name: "MachinePolicy"
+              value: {{ . | quote }}
+            {{- end }}
             - name: "DefaultNamespace"
               value: {{ .Values.agent.defaultNamespace | quote }}
             - name: "OCTOPUS__K8STENTACLE__NAMESPACE"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -46,7 +46,7 @@ spec:
               value: {{ join "," .Values.agent.targetEnvironments | quote }}
             - name: "TargetRole"
               value: {{ join "," .Values.agent.targetRoles | quote }}
-            {{- with .Values.agent.machinePolicy }}
+            {{- with .Values.agent.machinePolicyName }}
             - name: "MachinePolicy"
               value: {{ . | quote }}
             {{- end }}

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -13,6 +13,7 @@ agent:
   space: "Default"
   targetEnvironments: []
   targetRoles: []
+  machinePolicy: ""
   logLevel: "Info"
   defaultNamespace: ""
   pollingConnectionCount: 5

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -13,7 +13,7 @@ agent:
   space: "Default"
   targetEnvironments: []
   targetRoles: []
-  machinePolicy: ""
+  machinePolicyName: ""
   logLevel: "Info"
   defaultNamespace: ""
   pollingConnectionCount: 5


### PR DESCRIPTION
Allow users to specify a custom machine policy

[[sc-77359]](https://app.shortcut.com/octopusdeploy/story/77359/allow-users-to-set-the-machine-policy-in-the-helm-chart)