### PR TITLE
Update Tentacle to 8.1.1567

### DIFF
--- a/.changeset/violet-humans-relate.md
+++ b/.changeset/violet-humans-relate.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Update Tentacle to 8.1.1567. Contains a number of improvements and bug fixes. Fixes a known issue when registering where environment slugs don't match the environment names

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -7,4 +7,4 @@ version: "1.0.2"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "8.1.1518"
+appVersion: "8.1.1567"

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1518
+        app.kubernetes.io/version: 8.1.1567
         helm.sh/chart: kubernetes-agent-1.0.2
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1518
+        app.kubernetes.io/version: 8.1.1567
         helm.sh/chart: kubernetes-agent-1.0.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1518
+            app.kubernetes.io/version: 8.1.1567
             helm.sh/chart: kubernetes-agent-1.0.2
         spec:
           affinity:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -82,7 +82,7 @@ should match snapshot:
                   value: "5"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-tentacle:8.1.1518
+              image: octopusdeploy/kubernetes-tentacle:8.1.1567
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1518
+        app.kubernetes.io/version: 8.1.1567
         helm.sh/chart: kubernetes-agent-1.0.2
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1518
+        app.kubernetes.io/version: 8.1.1567
         helm.sh/chart: kubernetes-agent-1.0.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -21,8 +21,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-tentacle
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
-    tag: "8.1.1518"
+    tag: "8.1.1567"
    
   serviceAccount:
     # The name of the service account to use.


### PR DESCRIPTION
Updates the `kubernetes-tentacle` container to `8.1.1567`.

The version bump includes the following changes:
https://github.com/OctopusDeploy/OctopusTentacle/compare/8.1.1518...8.1.1567

There is 1 important bug fix in this release that fixes https://github.com/OctopusDeploy/Issues/issues/8760