### PR TITLE
Update Tentacle to 8.1.1588

### DIFF
--- a/.changeset/six-boxes-protect.md
+++ b/.changeset/six-boxes-protect.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Update Tentacle to 8.1.1588. Introduces new `KubernetesScriptServiceV1`.

--- a/.github/workflows/check-readme.yaml
+++ b/.github/workflows/check-readme.yaml
@@ -20,6 +20,7 @@ jobs:
         run: "npm run generate-agent-docs"
       - name: Check readme is unchanged
         run: |
+          git config --global core.autocrlf true
           echo "Ensuring readme is up-to-date"
           echo "If this test fails, run 'npm run generate-agent-docs' locally and commit the changes"
           git diff --exit-code

--- a/.github/workflows/check-readme.yaml
+++ b/.github/workflows/check-readme.yaml
@@ -20,6 +20,7 @@ jobs:
         run: "npm run generate-agent-docs"
       - name: Check readme is unchanged
         run: |
+          git config --global core.autocrlf input
           echo "Ensuring readme is up-to-date"
           echo "If this test fails, run 'npm run generate-agent-docs' locally and commit the changes"
-          git diff –ignore-line-endings --exit-code
+          git diff --exit-code

--- a/.github/workflows/check-readme.yaml
+++ b/.github/workflows/check-readme.yaml
@@ -13,6 +13,7 @@ jobs:
   check-readme:
     runs-on: ubuntu-latest
     steps:
+      - run: git config --global core.autocrlf true
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v4
       - name: Generate docs
@@ -20,7 +21,6 @@ jobs:
         run: "npm run generate-agent-docs"
       - name: Check readme is unchanged
         run: |
-          git config --global core.autocrlf input
           echo "Ensuring readme is up-to-date"
           echo "If this test fails, run 'npm run generate-agent-docs' locally and commit the changes"
           git diff --exit-code

--- a/.github/workflows/check-readme.yaml
+++ b/.github/workflows/check-readme.yaml
@@ -20,7 +20,6 @@ jobs:
         run: "npm run generate-agent-docs"
       - name: Check readme is unchanged
         run: |
-          git config --global core.autocrlf true
           echo "Ensuring readme is up-to-date"
           echo "If this test fails, run 'npm run generate-agent-docs' locally and commit the changes"
-          git diff --exit-code
+          git diff –ignore-line-endings --exit-code

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,8 +10,5 @@ maintainers:
     url: "https://octopus.com"
 type: application
 version: "1.0.3"
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "8.1.1567"
+# This version number should be the same as the agent.image.tag value as this is the primary application version
+appVersion: "8.1.1588"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,7 @@
 # kubernetes-agent
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1567](https://img.shields.io/badge/AppVersion-8.1.1567-informational?style=flat-square)
+
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1588](https://img.shields.io/badge/AppVersion-8.1.1588-informational?style=flat-square) 
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -26,7 +27,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.bearerToken | string | `""` | A JWT bearer token use to authenticate with the target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1567"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1588"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1567
+        app.kubernetes.io/version: 8.1.1588
         helm.sh/chart: kubernetes-agent-1.0.3
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1567
+        app.kubernetes.io/version: 8.1.1588
         helm.sh/chart: kubernetes-agent-1.0.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1567
+            app.kubernetes.io/version: 8.1.1588
             helm.sh/chart: kubernetes-agent-1.0.3
         spec:
           affinity:
@@ -82,7 +82,7 @@ should match snapshot:
                   value: "5"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-tentacle:8.1.1567
+              image: octopusdeploy/kubernetes-tentacle:8.1.1588
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1567
+        app.kubernetes.io/version: 8.1.1588
         helm.sh/chart: kubernetes-agent-1.0.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1567
+        app.kubernetes.io/version: 8.1.1588
         helm.sh/chart: kubernetes-agent-1.0.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -55,7 +55,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1567"
+    tag: "8.1.1588"
    
   serviceAccount:    
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
Updates the `kubernetes-tentacle` container to 8.1.1588.

The version bump includes the following changes:
https://github.com/OctopusDeploy/OctopusTentacle/compare/8.1.1567...8.1.1588

The key change is the introduction of the new `KubernetesScriptServiceV1`
