### PR TITLE
Add metrics configmap entry to helm chart

### DIFF
--- a/.changeset/cuddly-geckos-build.md
+++ b/.changeset/cuddly-geckos-build.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ConfigMap for agent metrics persistence

--- a/charts/kubernetes-agent/templates/kubernetes-agent-metrics-configmap.yml
+++ b/charts/kubernetes-agent/templates/kubernetes-agent-metrics-configmap.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-agent-metrics
+  namespace: {{ .Release.Namespace | quote }}
+data:

--- a/charts/kubernetes-agent/templates/tentacle-metrics-configmap.yml
+++ b/charts/kubernetes-agent/templates/tentacle-metrics-configmap.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tentacle-metrics
+  namespace: {{ .Release.Namespace | quote }}
+{{- with .Values.testing.tentacle.configMap.data }}
+data:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}

--- a/charts/kubernetes-agent/templates/tentacle-metrics-configmap.yml
+++ b/charts/kubernetes-agent/templates/tentacle-metrics-configmap.yml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tentacle-metrics
-  namespace: {{ .Release.Namespace | quote }}
-{{- with .Values.testing.tentacle.configMap.data }}
-data:
-  {{- toYaml . | nindent 2 }}
-{{- end -}}

--- a/charts/kubernetes-agent/tests/__snapshot__/kubernetes-agent-metrics-configmap_test.yml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/kubernetes-agent-metrics-configmap_test.yml.snap
@@ -1,0 +1,7 @@
+should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: kubernetes-agent-metrics
+      namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/kubernetes-agent-metrics-configmap_test.yml
+++ b/charts/kubernetes-agent/tests/kubernetes-agent-metrics-configmap_test.yml
@@ -1,0 +1,12 @@
+suite: "tentacle configuration"
+templates:
+  - templates/tentacle-configmap.yaml
+tests:
+  - it: "should match snapshot"
+    asserts:
+      - matchSnapshot: {}
+      
+  - it: "defaults to empty data (no data field)"
+    asserts:
+      - notExists:
+          path: data


### PR DESCRIPTION
This config map will be used by the agent to track failures (or other metrics).

Context: The health-check wrapper script will scrape this config map, and post the content back to OctopusDeploy a Json-blob in an OctopusVariable. 

This does not include options to populate from tests, its a first pass to get data being logged.
