### PR TITLE
Add token to checkout action

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -16,6 +16,8 @@ jobs:
     if: ${{ !startsWith(github.event.commits[0].message, 'Version Kubernetes Agent Chart') }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
     
     - name: setup-node
       uses: actions/setup-node@v4


### PR DESCRIPTION
The Versioning workflow creates a PR but the Kubernetes build/test/publish workflow doesn't run when the PR is created.

We think this is because it's using the `GITHUB_TOKEN` to authenticate.

I believe updating the checkout action to use the changeset token should make all subsequent usages of git use the same token which should fix the problem. Hard to say if it will work until after it's merged though.