### PR TITLE
Add startup probe for tentacle container

### DIFF
--- a/.changeset/neat-tigers-turn.md
+++ b/.changeset/neat-tigers-turn.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add startupProbe to Kubernetes tentacle container to ensure helm upgrade command doesn't return successful when the tentacle failed to initialise.

--- a/.changeset/neat-tigers-turn.md
+++ b/.changeset/neat-tigers-turn.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": minor
 ---
 
-Add startupProbe to Kubernetes tentacle container to ensure helm upgrade command doesn't return successful when the tentacle failed to initialise.
+Add startupProbe to Kubernetes tentacle container to ensure helm upgrade command doesn't return successful when the tentacle failed to initialise. This includes a Tentacle version bump to 8.1.1727.

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.2.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1717"
+appVersion: "8.1.1727"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1717](https://img.shields.io/badge/AppVersion-8.1.1717-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1727](https://img.shields.io/badge/AppVersion-8.1.1727-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -28,7 +28,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.certificate | string | `""` | A base64 formatted x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1717"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1727"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -36,7 +36,7 @@ spec:
               command:
                 - cat
                 - /etc/octopus/initialized
-            initialDelaySeconds: 10
+            initialDelaySeconds: 2
             periodSeconds: 2
           env:
             - name: "ACCEPT_EULA"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -31,6 +31,13 @@ spec:
         - name: {{printf "%s-tentacle" (include "kubernetes-agent.name" .) }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          startupProbe:
+            exec:
+              command:
+                - cat
+                - /scripts/initialised
+            initialDelaySeconds: 10
+            periodSeconds: 2
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.agent.acceptEula | quote }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             exec:
               command:
                 - cat
-                - /scripts/initialised
+                - /etc/octopus/initialized
             initialDelaySeconds: 10
             periodSeconds: 2
           env:

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1717
+        app.kubernetes.io/version: 8.1.1727
         helm.sh/chart: kubernetes-agent-1.2.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -91,6 +91,13 @@ should match snapshot:
                 requests:
                   cpu: 100m
                   memory: 150Mi
+              startupProbe:
+                exec:
+                  command:
+                    - cat
+                    - /scripts/initialised
+                initialDelaySeconds: 10
+                periodSeconds: 2
               volumeMounts:
                 - mountPath: /octopus
                   name: tentacle-home

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -96,7 +96,7 @@ should match snapshot:
                   command:
                     - cat
                     - /etc/octopus/initialized
-                initialDelaySeconds: 10
+                initialDelaySeconds: 2
                 periodSeconds: 2
               volumeMounts:
                 - mountPath: /octopus

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1717
+        app.kubernetes.io/version: 8.1.1727
         helm.sh/chart: kubernetes-agent-1.2.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1717
+            app.kubernetes.io/version: 8.1.1727
             helm.sh/chart: kubernetes-agent-1.2.0
         spec:
           affinity:
@@ -84,7 +84,7 @@ should match snapshot:
                   value: "5"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-tentacle:8.1.1717
+              image: octopusdeploy/kubernetes-tentacle:8.1.1727
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:
@@ -95,7 +95,7 @@ should match snapshot:
                 exec:
                   command:
                     - cat
-                    - /scripts/initialised
+                    - /etc/octopus/initialized
                 initialDelaySeconds: 10
                 periodSeconds: 2
               volumeMounts:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1717
+        app.kubernetes.io/version: 8.1.1727
         helm.sh/chart: kubernetes-agent-1.2.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1717
+        app.kubernetes.io/version: 8.1.1727
         helm.sh/chart: kubernetes-agent-1.2.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -64,7 +64,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1717"
+    tag: "8.1.1727"
    
   serviceAccount:    
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
# Background

Currently you can run the helm upgrade command for a Kubernetes agent and it will install and helm will be happy even if there is no server running to connect to.

When the tentacle starts up, Kubernetes sees the container running and helm just thinks it's good to go, even though the configuration/initialisation hasn't completed yet. This can put the agent in a situation where the Tentacle container is constantly bootlooping, unable to do anything while the helm chart returned happy.

# Results

This change is partnered with a Tentacle change (https://github.com/OctopusDeploy/OctopusTentacle/pull/953) which creates an empty file when the tentacle container is finished initialising on startup. The startup probe simply checks to see if the file exists and as soon as it does the container is considered "ready" and then the helm chart can complete successfully. 

[sc-80003]