### PR TITLE
Fix memory leak when Kubernetes Start Script fails

### DIFF
--- a/.changeset/tasty-countries-invite.md
+++ b/.changeset/tasty-countries-invite.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Bump Tentacle version to 8.1.1734 to include a fix for a memory leak when StartScript fails.

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.3.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1727"
+appVersion: "8.1.1734"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1727](https://img.shields.io/badge/AppVersion-8.1.1727-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1734](https://img.shields.io/badge/AppVersion-8.1.1734-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -28,7 +28,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.certificate | string | `""` | A base64 formatted x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1727"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-tentacle","tag":"8.1.1734"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1727
+        app.kubernetes.io/version: 8.1.1734
         helm.sh/chart: kubernetes-agent-1.3.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1727
+        app.kubernetes.io/version: 8.1.1734
         helm.sh/chart: kubernetes-agent-1.3.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1727
+            app.kubernetes.io/version: 8.1.1734
             helm.sh/chart: kubernetes-agent-1.3.0
         spec:
           affinity:
@@ -84,7 +84,7 @@ should match snapshot:
                   value: "5"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-tentacle:8.1.1727
+              image: octopusdeploy/kubernetes-tentacle:8.1.1734
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1727
+        app.kubernetes.io/version: 8.1.1734
         helm.sh/chart: kubernetes-agent-1.3.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1727
+        app.kubernetes.io/version: 8.1.1734
         helm.sh/chart: kubernetes-agent-1.3.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -64,7 +64,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1727"
+    tag: "8.1.1734"
    
   serviceAccount:    
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
## Background

There was a possible memory leak when KubernetesScriptServiceV1.StartScript fails (e.g. pod creation error) because the SemaphoreSlim is not removed from the concurrent dictionary which will grow in size.

[sc-77248]

## Results
This version bump is partnered with a [Tentacle change](https://github.com/OctopusDeploy/OctopusTentacle/pull/946) that ensures the proper disposal of semaphore references in the event of an exception during the StartScript execution.