### PR TITLE
Add pods/exec permission to tentacle deployment

### DIFF
--- a/charts/kubernetes-agent/templates/tentacle-role.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-role.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: ["*"]
-  resources: ["pods", "pods/log", "configmaps", "secrets"]
+  resources: ["pods", "pods/log", "pods/exec", "configmaps", "secrets"]
   verbs: ["*"]


### PR DESCRIPTION
This is required if we want to be able to use the `Client.NamespacedPodExecAsync()` command like in:
https://github.com/OctopusDeploy/OctopusTentacle/pull/960

https://github.com/OctopusDeploy/OctopusDeploy/pull/25256