### PR TITLE
change nfs stateful set

### DIFF
--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
           volumeMounts:
           - mountPath: /octopus
             name: octopus-volume
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 31
       volumes:
         - name: octopus-volume
           emptyDir:

--- a/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
@@ -50,7 +50,7 @@ should match snapshot:
               volumeMounts:
                 - mountPath: /octopus
                   name: octopus-volume
-          terminationGracePeriodSeconds: 30
+          terminationGracePeriodSeconds: 31
           volumes:
             - emptyDir:
                 sizeLimit: 10Gi


### PR DESCRIPTION
This is to test that a server-driven update of the agent which causes an NFS pod restart will complete successfully.

Not to merge.