### PR TITLE
Allow kubernetes agent user to raise events

### DIFF
--- a/.changeset/wild-parents-appear.md
+++ b/.changeset/wild-parents-appear.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add permission for octopus user to raise kubernetes events

--- a/charts/kubernetes-agent/templates/tentacle-role.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-role.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups: ["*"]
-  resources: ["pods", "pods/log", "configmaps", "secrets"]
+  resources: ["pods", "pods/log", "configmaps", "secrets", "events"]
   verbs: ["*"]

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-role_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-role_test.yaml.snap
@@ -13,5 +13,6 @@ should match snapshot:
           - pods/log
           - configmaps
           - secrets
+          - events
         verbs:
           - '*'


### PR DESCRIPTION
This is required to allow the nfs-watchdog to raise events.