### PR TITLE
Use Artifactory to source the Kubernetes agent helm chart instead of Dockerhub

### DIFF
--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
@@ -16,6 +16,7 @@ public class KubernetesAgentInstaller
 {
     //This is the DNS of the localhost Kubernetes Server we add to the cluster in the KubernetesClusterInstaller.SetLocalhostRouting()
     const string LocalhostKubernetesServiceDns = "dockerhost.default.svc.cluster.local";
+    const string ArtifactoryAgentOciRepository = "oci://docker.packages.octopushq.com/kubernetes-agent";
 
     readonly string helmExePath;
     readonly string kubeCtlExePath;
@@ -105,7 +106,7 @@ public class KubernetesAgentInstaller
 
     string BuildAgentInstallArguments(string valuesFilePath)
     {
-        var (chartVersion, chartRepo) = GetChartVersionAndRepository();
+        var chartVersion = GetChartVersion();
         var args = new[]
         {
             "upgrade",
@@ -117,19 +118,17 @@ public class KubernetesAgentInstaller
             NamespaceFlag,
             KubeConfigFlag,
             AgentName,
-            chartRepo
+            ArtifactoryAgentOciRepository
         };
 
         return string.Join(" ", args.WhereNotNull());
     }
 
-    static (string ChartVersion, string ChartRepo) GetChartVersionAndRepository()
+    static string GetChartVersion()
     {
         var customHelmChartVersion = Environment.GetEnvironmentVariable("KubernetesIntegrationTests_HelmChartVersion");
-        
-        return !string.IsNullOrWhiteSpace(customHelmChartVersion) 
-            ? (customHelmChartVersion, "oci://docker.packages.octopushq.com/kubernetes-agent") 
-            : ("1.*.*", "oci://registry-1.docker.io/octopusdeploy/kubernetes-agent");
+
+        return !string.IsNullOrWhiteSpace(customHelmChartVersion) ? customHelmChartVersion : "1.*.*";
     }
 
     static string? GetImageAndRepository(string? tentacleImageAndTag)


### PR DESCRIPTION
# Background

We've been hitting rate limiting because docker is tightening up their rate limits.

# Results

Instead of doing what we do in server which is to return inconclusive when dockerhub rate limits our request, we are just going to use Artifactory. This will eliminate the rate limiting but could cause failures if artifactory is done. Because this test doesn't have to run on the same scale as server, we don't need to stress too much about this. If it does fail, we can just rerun the test.