### PR TITLE
Bump Tentacle Version to add full agent upgrade support

### DIFF
--- a/.changeset/mighty-melons-sniff.md
+++ b/.changeset/mighty-melons-sniff.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": minor
 ---
 
-Bump Tentacle version (to 8.1.1819) to add full server-driven upgrade support
+Upgrade kubernetes-agent-tentacle to 8.1.1819 to support more reliable server-driven upgrades

--- a/.changeset/mighty-melons-sniff.md
+++ b/.changeset/mighty-melons-sniff.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Bump Tentacle version (to 8.1.1819) to add full server-driven upgrade support

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.5.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1758"
+appVersion: "8.1.1819"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1758](https://img.shields.io/badge/AppVersion-8.1.1758-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1819](https://img.shields.io/badge/AppVersion-8.1.1819-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1758"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1819"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1758
+        app.kubernetes.io/version: 8.1.1819
         helm.sh/chart: kubernetes-agent-1.5.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1758
+        app.kubernetes.io/version: 8.1.1819
         helm.sh/chart: kubernetes-agent-1.5.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1758
+            app.kubernetes.io/version: 8.1.1819
             helm.sh/chart: kubernetes-agent-1.5.0
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1758
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1819
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1758
+        app.kubernetes.io/version: 8.1.1819
         helm.sh/chart: kubernetes-agent-1.5.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1758
+        app.kubernetes.io/version: 8.1.1819
         helm.sh/chart: kubernetes-agent-1.5.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -76,7 +76,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1758"
+    tag: "8.1.1819"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
@@ -13,8 +13,8 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="Octopus.Client" Version="14.3.1381" />
-        <PackageReference Include="Octopus.Tentacle.Client" Version="8.1.1594" />
+        <PackageReference Include="Octopus.Client" Version="14.3.1463" />
+        <PackageReference Include="Octopus.Tentacle.Client" Version="8.1.1819" />
         <PackageReference Include="Serilog" Version="3.1.1" />
         <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
         <PackageReference Include="xunit" Version="2.5.3"/>

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/RunsAgentUpgrade.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/RunsAgentUpgrade.cs
@@ -59,9 +59,11 @@ public class HelmUpgradeTests(ITestOutputHelper output) : IAsyncLifetime
              /tmp/{packageName}
              """;
         var upgradeHelmChartCommand = new ExecuteKubernetesScriptCommandBuilder(Guid.NewGuid().ToString())
+            .IsRawScript()
             .WithScriptBody($"cp ./{packageName} /tmp/{packageName} && {helmUpgradeScript}")
             .WithScriptFile(new ScriptFile(packageName, DataStream.FromBytes(packageBytes)))
             .Build();
+
         void onScriptStatusResponseReceived(ScriptExecutionStatus res) => logger.Information("{Output}", res.ToString());
         async Task onScriptCompleted(CancellationToken t)
         {

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/Common/TestLogger.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/Common/TestLogger.cs
@@ -1,225 +1,37 @@
 using System;
-using Octopus.Diagnostics;
-using ILog = Octopus.Diagnostics.ILog;
+using Octopus.Tentacle.Contracts.Logging;
 
 namespace KubernetesAgent.Integration.Setup.Common
 {
-    public sealed class TestLogger(ILogger logger) : ILog, IDisposable
+    public sealed class TestLogger(ILogger logger) : ITentacleClientTaskLog
     {
-        readonly ILogger logger = logger;
-        
-        public string CorrelationId { get; }
-        
+        public void Info(string message)
+        {
+            logger.Information(message);
+        }
+
+        public void Verbose(string message)
+        {
+            logger.Verbose(message);
+        }
+
+        public void Verbose(Exception exception)
+        {
+            logger.Verbose(exception, "");
+        }
+
+        public void Warn(string message)
+        {
+            logger.Warning(message);
+        }
+
+        public void Warn(Exception exception, string message)
+        {
+            logger.Warning(exception, message);
+        }
+
         public void Dispose()
         {
-            Flush();
         }
-
-        public void WithSensitiveValues(string[] sensitiveValues)
-        {
-        }
-
-        public void WithSensitiveValue(string sensitiveValue)
-        {
-        }
-        
-        public void Write(LogCategory category, string messageText)
-        {
-            Write(category, null, messageText);
-        }
-
-        public void Write(LogCategory category, Exception error)
-        {
-            WriteFormat(category, error.Message);
-        }
-
-        public void Write(LogCategory category, Exception? error, string messageText)
-        {
-            WriteFormat(category, "Exception: {Message}, Message: {Message}", error?.Message ?? "", messageText);
-        }
-
-        public void WriteFormat(LogCategory category, string messageFormat, params object[] args)
-        {
-            WriteFormat(category, null, messageFormat, args);
-        }
-
-        public void WriteFormat(LogCategory category, Exception? error, string messageFormat, params object[] args)
-        {
-            switch (category)
-            {
-                case LogCategory.Trace:
-                case LogCategory.Verbose:
-                    logger.Debug(messageFormat, args);
-                    break;
-                case LogCategory.Info:
-                case LogCategory.Planned:
-                case LogCategory.Highlight:
-                case LogCategory.Abandoned:
-                case LogCategory.Wait:
-                case LogCategory.Progress:
-                    logger.Information(messageFormat, args);
-                    break;
-                case LogCategory.Finished:
-                case LogCategory.Warning:
-                case LogCategory.Error:
-                case LogCategory.Fatal:
-                    logger.Error(messageFormat, args);
-                    break;
-            }
-        }
-        
-        public void Trace(string messageText)
-        {
-            Write(LogCategory.Trace, messageText);
-        }
-
-        public void Trace(Exception error)
-        {
-            Write(LogCategory.Trace, error);
-        }
-
-        public void Trace(Exception error, string message)
-        {
-            Write(LogCategory.Trace, error, message);
-        }
-
-        public void TraceFormat(string messageFormat, params object[] args)
-        {
-            WriteFormat(LogCategory.Trace, messageFormat, args);
-        }
-
-        public void TraceFormat(Exception error, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Trace, error, format, args);
-        }
-
-        public void Verbose(string messageText)
-        {
-            Write(LogCategory.Verbose, messageText);
-        }
-
-        public void Verbose(Exception error)
-        {
-            Write(LogCategory.Verbose, error);
-        }
-
-        public void Verbose(Exception error, string message)
-        {
-            Write(LogCategory.Verbose, error, message);
-        }
-
-        public void VerboseFormat(string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Verbose, format, args);
-        }
-
-        public void VerboseFormat(Exception error, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Verbose, error, format, args);
-        }
-
-        public void Info(string messageText)
-        {
-            Write(LogCategory.Info, messageText);
-        }
-
-        public void Info(Exception error)
-        {
-            Write(LogCategory.Info, error);
-        }
-
-        public void Info(Exception error, string message)
-        {
-            Write(LogCategory.Info, error, message);
-        }
-
-        public void InfoFormat(string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Info, format, args);
-        }
-
-        public void InfoFormat(Exception error, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Info, error, format, args);
-        }
-
-        public void Warn(string messageText)
-        {
-            Write(LogCategory.Warning, messageText);
-        }
-
-        public void Warn(Exception error)
-        {
-            Write(LogCategory.Warning, error);
-        }
-
-        public void Warn(Exception error, string messageText)
-        {
-            Write(LogCategory.Warning, error, messageText);
-        }
-
-        public void WarnFormat(string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Warning, format, args);
-        }
-
-        public void WarnFormat(Exception exception, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Warning, exception, format, args);
-        }
-
-        public void Error(string messageText)
-        {
-            Write(LogCategory.Error, messageText);
-        }
-
-        public void Error(Exception error)
-        {
-            Write(LogCategory.Error, error);
-        }
-
-        public void Error(Exception error, string messageText)
-        {
-            Write(LogCategory.Error, error, messageText);
-        }
-
-        public void ErrorFormat(string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Error, format, args);
-        }
-
-        public void ErrorFormat(Exception exception, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Error, exception, format, args);
-        }
-
-        public void Fatal(string messageText)
-        {
-            Write(LogCategory.Fatal, messageText);
-        }
-
-        public void Fatal(Exception error)
-        {
-            Write(LogCategory.Fatal, error);
-        }
-
-        public void Fatal(Exception error, string messageText)
-        {
-            Write(LogCategory.Fatal, error, messageText);
-        }
-
-        public void FatalFormat(string messageFormat, params object[] args)
-        {
-            WriteFormat(LogCategory.Fatal, messageFormat, args);
-        }
-
-        public void FatalFormat(Exception exception, string format, params object[] args)
-        {
-            WriteFormat(LogCategory.Fatal, exception, format, args);
-        }
-
-        public void Flush()
-        { }
-
     }
 }


### PR DESCRIPTION
# Background

The Server and Tentacle changes have been merged to allow server to run raw scripts without an active NFS mount. This allows server to upgrade the agent even if the NFS pod needs to be restarted.

# Results

Bumping Tentacle to this version brings the functionality officially the the Kubernetes agent. I've also updated the test to use the `IsRawScript` option in the upgrade test to ensure that the changes are tested.