### PR TITLE
Allow configuring proxy environment variables

### DIFF
--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -105,6 +105,22 @@ spec:
                 {{- end }}
                   - name: OCTOPUS_INSTALLED_VIA_HELM 
                     value: "true"
+                {{- if .Values.octopus.proxy.http }}
+                  - name: HTTP_PROXY
+                    value: {{ .Values.octopus.proxy.http | quote }}
+                {{- end }}
+                {{- if .Values.octopus.proxy.https }}
+                  - name: HTTPS_PROXY
+                    value: {{ .Values.octopus.proxy.https | quote }}
+                {{- end }}
+                {{- if .Values.octopus.proxy.all }}
+                  - name: ALL_PROXY
+                    value: {{ .Values.octopus.proxy.all | quote }}
+                {{- end }}
+                {{- if .Values.octopus.proxy.none }}
+                  - name: NO_PROXY
+                    value: {{ .Values.octopus.proxy.none | quote }}
+                {{- end }}
                 ports:
                   - containerPort: 8080
                     name: web

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -117,9 +117,9 @@ spec:
                   - name: ALL_PROXY
                     value: {{ .Values.octopus.proxy.all | quote }}
                 {{- end }}
-                {{- if .Values.octopus.proxy.none }}
+                {{- if .Values.octopus.proxy.excludedHostnames }}
                   - name: NO_PROXY
-                    value: {{ .Values.octopus.proxy.none | quote }}
+                    value: {{ join "," .Values.octopus.proxy.excludedHostnames | quote }}
                 {{- end }}
                 ports:
                   - containerPort: 8080

--- a/charts/octopus-deploy/tests/statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/statefulset_test.yaml
@@ -78,15 +78,19 @@ tests:
       - ./values/required.yaml
       - ./values/proxy.yaml
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: HTTP_PROXY
-            value: http://myproxy.com
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'HTTP_PROXY')].value
+          value: http://myproxy.com
         documentIndex: 0
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: HTTPS_PROXY
-            value: https://myproxy.com
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'HTTPS_PROXY')].value
+          value: https://myproxy.com
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'ALL_PROXY')].value
+          value: https://myproxy.com
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'NO_PROXY')].value
+          value: example.com,example2.com
         documentIndex: 0

--- a/charts/octopus-deploy/tests/statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/statefulset_test.yaml
@@ -72,3 +72,21 @@ tests:
             name: "ACCEPT_EULA"
             value: "N"
         documentIndex: 0
+  
+  - it: proxy is configurable
+    values:
+      - ./values/required.yaml
+      - ./values/proxy.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+            value: http://myproxy.com
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: https://myproxy.com
+        documentIndex: 0

--- a/charts/octopus-deploy/tests/values/proxy.yaml
+++ b/charts/octopus-deploy/tests/values/proxy.yaml
@@ -2,3 +2,7 @@ octopus:
   proxy:
     http: http://myproxy.com
     https: https://myproxy.com
+    all: https://myproxy.com
+    excludedHostnames:
+      - example.com
+      - example2.com

--- a/charts/octopus-deploy/tests/values/proxy.yaml
+++ b/charts/octopus-deploy/tests/values/proxy.yaml
@@ -1,0 +1,4 @@
+octopus:
+  proxy:
+    http: http://myproxy.com
+    https: https://myproxy.com

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -104,6 +104,16 @@ octopus:
     annotations: {}
     labels: {}
 
+  proxy:
+    # the proxy to use for http requests
+    http:
+    # the proxy to use for https requests
+    https:
+    # the proxy to use for http and/or https requests, in case the above two values are not defined
+    all:
+    # a comma-separated list of hostnames that should be excluded from proxying
+    none:
+  
   # For minimum resource indications see https://octopus.com/docs/administration/managing-infrastructure/performance#minimum-requirements 
   resources: {} 
   #  requests:

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -111,7 +111,7 @@ octopus:
     https:
     # the proxy to use for http and/or https requests, in case the above two values are not defined
     all:
-    # a comma-separated list of hostnames that should be excluded from proxying
+    # an array of hostnames that should be excluded from proxying
     excludedHostnames: []
   
   # For minimum resource indications see https://octopus.com/docs/administration/managing-infrastructure/performance#minimum-requirements 

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -112,7 +112,7 @@ octopus:
     # the proxy to use for http and/or https requests, in case the above two values are not defined
     all:
     # a comma-separated list of hostnames that should be excluded from proxying
-    none:
+    excludedHostnames: []
   
   # For minimum resource indications see https://octopus.com/docs/administration/managing-infrastructure/performance#minimum-requirements 
   resources: {} 


### PR DESCRIPTION
A customer is working on PoC running Octopus in Kubernetes but there's no way to configure the proxy to use, this PR adds the ability to configure the `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables in the container.

[sc-82304]