### PR TITLE
Update Kubernetes agent Github actions to publish package to Octopus

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -144,3 +144,11 @@ jobs:
         release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
         package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
         ignore_existing: true
+
+  publish_artifactory:
+    runs-on: ubuntu-latest
+    if: false
+
+  publish_dockerhub:
+    runs-on: ubuntu-latest
+    if: false

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -132,15 +132,15 @@ jobs:
     - name: Push helm chart to Octopus Deploy 🐙
       uses: OctopusDeploy/push-package-action@v3
       with:
-        space: 'modern-deployments'
+        space: 'Modern Deployments'
         packages: ${{ needs.version_and_package.outputs.PACKAGE_NAME }}
         overwrite_mode: IgnoreIfExists
 
     - name: Create a release in Octopus Deploy 🐙
       uses: OctopusDeploy/create-release-action@v3
       with:
-        space: 'modern-deployments'
-        project: 'octopus-kubernetes-agent'
+        space: 'Modern Deployments'
+        project: 'Octopus Kubernetes Agent'
         release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
         package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
         ignore_existing: true

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -136,15 +136,6 @@ jobs:
         packages: ${{ needs.version_and_package.outputs.PACKAGE_NAME }}
         overwrite_mode: IgnoreIfExists
 
-    - name: Create a release in Octopus Deploy 🐙
-      uses: OctopusDeploy/create-release-action@v3
-      with:
-        space: 'Modern Deployments'
-        project: 'Octopus Kubernetes Agent'
-        release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
-        package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
-        ignore_existing: true
-
   publish_artifactory:
     runs-on: ubuntu-latest
     if: false

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -141,6 +141,6 @@ jobs:
       with:
         space: 'Modern Deployments'
         project: 'Octopus Kubernetes Agent'
-        release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
-        package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        release_number: ${{ env.CHART_VERSION }}
+        package_version: ${{ env.CHART_VERSION }}
         ignore_existing: true

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -123,8 +123,8 @@ jobs:
     - name: Login to Octopus
       uses: OctopusDeploy/login@v1
       with:
-        server: ${{ secrets.OCTOPUS_SERVER }}
-        service_account_id: ${{ vars.OCTOPUS_SERVICE_ACCOUNT }}
+        server: ${{ vars.OCTOPUS_SERVER }}
+        service_account_id: ${{ secrets.OCTOPUS_SERVICE_ACCOUNT }}
 
     - name: Push helm chart to Octopus Deploy 🐙
       uses: OctopusDeploy/push-package-action@v3

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -114,6 +114,9 @@ jobs:
     # We publish to Artifactory if this is not a main commit, or if it is, that it's a versioning commit
     if: ${{ github.ref != 'refs/heads/main' || (github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'Version Kubernetes Agent Chart')) }}
     needs: version_and_package
+    permissions:
+      # You might need to add other permissions here like `contents: read` depending on what else your job needs to do
+      id-token: write # This is required to obtain an ID token from GitHub Actions for the job
     steps:
     - name: Download packaged chart
       uses: actions/download-artifact@v3

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -109,47 +109,35 @@ jobs:
         name: '${{ steps.version.outputs.PACKAGE_NAME }}'
         path: '${{ github.workspace }}/kubernetes-agent-${{ env.CHART_VERSION }}.tgz'
 
-  publish_artifactory:
+  publish_to_octopus:
     runs-on: ubuntu-latest
     # We publish to Artifactory if this is not a main commit, or if it is, that it's a versioning commit
     if: ${{ github.ref != 'refs/heads/main' || (github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'Version Kubernetes Agent Chart')) }}
     needs: version_and_package
     steps:
-    - name: Install Helm
-      uses: azure/setup-helm@v3
-      with:
-        version: 'v3.13.2'
-
     - name: Download packaged chart
       uses: actions/download-artifact@v3
       with:
         name: '${{ needs.version_and_package.outputs.PACKAGE_NAME }}'
 
-    - name: Login to Artifactory
-      run: echo '${{ secrets.ARTIFACTORY_PASSWORD }}' | helm registry login ${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }} -u '${{ secrets.ARTIFACTORY_USERNAME }}' --password-stdin
-
-    - name: Push Chart to Artifactory
-      run: helm push '${{ needs.version_and_package.outputs.PACKAGE_NAME }}' oci://${{ secrets.ARTIFACTORY_DOCKER_REPO_HOSTNAME }}
-
-  publish_dockerhub:
-    runs-on: ubuntu-latest
-    # We only publish to docker hub if this is commit to main and the comment is a chart versioning commit
-    if: ${{ github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'Version Kubernetes Agent Chart') }}
-    needs: version_and_package
-    steps:
-    - name: Install Helm
-      uses: azure/setup-helm@v3
+    - name: Login to Octopus
+      uses: OctopusDeploy/login@v1
       with:
-        version: 'v3.13.2'
+        server: ${{ secrets.OCTOPUS_SERVER }}
+        service_account_id: ${{ vars.OCTOPUS_SERVICE_ACCOUNT }}
 
-    - name: Download packaged chart
-      uses: actions/download-artifact@v3
+    - name: Push helm chart to Octopus Deploy 🐙
+      uses: OctopusDeploy/push-package-action@v3
       with:
-        name: '${{ needs.version_and_package.outputs.PACKAGE_NAME }}'
+        space: 'modern-deployments'
+        packages: ${{ needs.version_and_package.outputs.PACKAGE_NAME }}
+        overwrite_mode: IgnoreIfExists
 
-    - name: Login to DockerHub
-      run: echo '${{ secrets.DOCKERHUB_TOKEN }}' | helm registry login registry-1.docker.io -u '${{ secrets.DOCKERHUB_USERNAME }}' --password-stdin
-
-    - name: Push Chart to DockerHub
-      run: helm push '${{ needs.version_and_package.outputs.PACKAGE_NAME }}' oci://registry-1.docker.io/octopusdeploy
-
+    - name: Create a release in Octopus Deploy 🐙
+      uses: OctopusDeploy/create-release-action@v3
+      with:
+        space: 'modern-deployments'
+        project: 'octopus-kubernetes-agent'
+        release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        ignore_existing: true

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -97,17 +97,17 @@ jobs:
 
         full_version="$chart_version$pre_release"
 
-        echo "CHART_VERSION=$full_version" >> $GITHUB_ENV
+        echo "CHART_VERSION=$full_version" >> $GITHUB_OUTPUT
         echo "PACKAGE_NAME=kubernetes-agent-$full_version.tgz" >> $GITHUB_OUTPUT
 
     - name: Package Chart
-      run: helm package './charts/kubernetes-agent' --version '${{ env.CHART_VERSION }}'
+      run: helm package './charts/kubernetes-agent' --version '${{ steps.version.outputs.CHART_VERSION }}'
 
     - uses: actions/upload-artifact@v3
       name: Upload packaged chart
       with:
         name: '${{ steps.version.outputs.PACKAGE_NAME }}'
-        path: '${{ github.workspace }}/kubernetes-agent-${{ env.CHART_VERSION }}.tgz'
+        path: '${{ github.workspace }}/kubernetes-agent-${{ steps.version.outputs.CHART_VERSION }}.tgz'
 
   publish_to_octopus:
     runs-on: ubuntu-latest
@@ -141,6 +141,6 @@ jobs:
       with:
         space: 'Modern Deployments'
         project: 'Octopus Kubernetes Agent'
-        release_number: ${{ env.CHART_VERSION }}
-        package_version: ${{ env.CHART_VERSION }}
+        release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
         ignore_existing: true

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -148,7 +148,13 @@ jobs:
   publish_artifactory:
     runs-on: ubuntu-latest
     if: false
+    steps:
+    - shell: bash
+      run: echo "no-op"
 
   publish_dockerhub:
     runs-on: ubuntu-latest
     if: false
+    steps:
+    - shell: bash
+      run: echo "no-op"


### PR DESCRIPTION
# Background

We are preparing the Kubernetes agent to go into v2 prerelease and we want to better manage which versions are release to dockerhub. To do this we've decided to publish the helm chart as a package to the Deploy instance of Octopus and manage the release from there.

# Results

I've replaced the appropriate Github actions, we'll use OIDC to authenticate with the Deploy instance.