### PR TITLE
Add support for custom Octopus Server SSL/TLS certificates

### DIFF
--- a/.changeset/slow-hotels-do.md
+++ b/.changeset/slow-hotels-do.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add support for custom Octopus Server SSL/TLS certificates"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.6.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1819"
+appVersion: "8.1.1838"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,10 +1,11 @@
 # kubernetes-agent
 
+
 ![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1819](https://img.shields.io/badge/AppVersion-8.1.1819-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
 
 ## Maintainers
@@ -36,6 +37,8 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key use to authenticate with the target Octopus Server |
+| agent.serverCA | object | `{"encodedCertificate":""}` | If the Octopus Server has a custom certificate, it's public key can be added here |
+| agent.serverCA.encodedCertificate | string | `""` | The base64-encoded public certificate used by Octopus Server |
 | agent.serverCommsAddress | string | `""` | The polling communication URL of the target Octopus Server |
 | agent.serverCommsAddresses | list | `[]` | The polling communication URLs of the target Octopus Servers when running in High Availability (HA) |
 | agent.serverSubscriptionId | string | `""` | The subscription ID that is used to by the agent to identify itself with Octopus Server |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,5 @@
 # kubernetes-agent
 
-
 ![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1819](https://img.shields.io/badge/AppVersion-8.1.1819-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -25,7 +25,7 @@ A Helm chart for the Octopus Kubernetes Agent
 |-----|------|---------|-------------|
 | agent.acceptEula | string | `"N"` | Setting to Y accepts the [Customer Agreement](https://octopus.com/company/legal) |
 | agent.bearerToken | string | `""` | A JWT bearer token use to authenticate with the target Octopus Server |
-| agent.certificate | string | `""` | A base64 formatted x509 certificate used to setup a trust between the agent and target Octopus Server |
+| agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
@@ -36,8 +36,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key use to authenticate with the target Octopus Server |
-| agent.serverCA | object | `{"encodedCertificate":""}` | If the Octopus Server has a custom certificate, it's public key can be added here |
-| agent.serverCA.encodedCertificate | string | `""` | The base64-encoded public certificate used by Octopus Server |
+| agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |
 | agent.serverCommsAddress | string | `""` | The polling communication URL of the target Octopus Server |
 | agent.serverCommsAddresses | list | `[]` | The polling communication URLs of the target Octopus Servers when running in High Availability (HA) |
 | agent.serverSubscriptionId | string | `""` | The subscription ID that is used to by the agent to identify itself with Octopus Server |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1819](https://img.shields.io/badge/AppVersion-8.1.1819-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1838](https://img.shields.io/badge/AppVersion-8.1.1838-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1819"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1838"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -127,7 +127,7 @@ spec:
           volumeMounts:
             - mountPath: /octopus
               name: tentacle-home  
-            {{- if .Values.agent.serverCA.encodedCertificate }}
+            {{- if .Values.agent.serverCertificate }}
             - name: octopus-server-certificate-configmap
               mountPath: /etc/ssl/certs/octopus-server-certificate.pem
               subPath: octopus-server-certificate.pem
@@ -174,7 +174,7 @@ spec:
         - name: tentacle-home
           persistentVolumeClaim:
             claimName: {{ include "kubernetes-agent.pvcName" .}}
-        {{- if .Values.agent.serverCA.encodedCertificate }}
+        {{- if .Values.agent.serverCertificate }}
         - name: octopus-server-certificate-configmap
           configMap:
             name: "octopus-server-certificate"

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -126,7 +126,13 @@ spec:
           {{- end}}
           volumeMounts:
             - mountPath: /octopus
-              name: tentacle-home
+              name: tentacle-home  
+            {{- if .Values.agent.serverCA.encodedCertificate }}
+            - name: octopus-server-certificate-configmap
+              mountPath: /etc/ssl/certs/octopus-server-certificate.pem
+              subPath: octopus-server-certificate.pem
+              readOnly: false
+            {{- end }}
         {{- if and .Values.persistence.nfs.watchdog.enabled (not .Values.persistence.storageClassName) }}
         - name: nfs-watchdog
           image: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
@@ -168,3 +174,9 @@ spec:
         - name: tentacle-home
           persistentVolumeClaim:
             claimName: {{ include "kubernetes-agent.pvcName" .}}
+        {{- if .Values.agent.serverCA.encodedCertificate }}
+        - name: octopus-server-certificate-configmap
+          configMap:
+            name: "octopus-server-certificate"
+        {{- end }}
+

--- a/charts/kubernetes-agent/templates/tentacle-server-cert-configmap.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-cert-configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.agent.serverCA.encodedCertificate }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: octopus-server-certificate
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  octopus-server-certificate.pem: {{ .Values.agent.serverCA.encodedCertificate | b64dec | quote }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-server-cert-configmap.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-cert-configmap.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.agent.serverCA.encodedCertificate }}
+{{- if .Values.agent.serverCertificate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: octopus-server-certificate
   namespace: {{ .Release.Namespace | quote }}
 data:
-  octopus-server-certificate.pem: {{ .Values.agent.serverCA.encodedCertificate | b64dec | quote }}
+  octopus-server-certificate.pem: {{ .Values.agent.serverCertificate | b64dec | quote }}
 {{- end }}

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1819
+        app.kubernetes.io/version: 8.1.1838
         helm.sh/chart: kubernetes-agent-1.6.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1819
+        app.kubernetes.io/version: 8.1.1838
         helm.sh/chart: kubernetes-agent-1.6.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1819
+            app.kubernetes.io/version: 8.1.1838
             helm.sh/chart: kubernetes-agent-1.6.0
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1819
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1838
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1819
+        app.kubernetes.io/version: 8.1.1838
         helm.sh/chart: kubernetes-agent-1.6.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-server-cert-configmap_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-server-cert-configmap_test.yaml.snap
@@ -1,0 +1,9 @@
+matches snapshot:
+  1: |
+    apiVersion: v1
+    data:
+      octopus-server-certificate.pem: test-text
+    kind: ConfigMap
+    metadata:
+      name: octopus-server-certificate
+      namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1819
+        app.kubernetes.io/version: 8.1.1838
         helm.sh/chart: kubernetes-agent-1.6.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -137,3 +137,30 @@ tests:
       - equal:
           path: metadata.name
           value: thisisaverylongstring34087236548972364802367y408923604872341234-tentacle
+
+  - it: "mounts octopus server certificate when encoded certificate provided"
+    set:
+      agent:
+        serverCA:
+          encodedCertificate: "dGVzdC10ZXh0"
+    asserts:
+      - exists:
+          path: spec.template.spec.volumes[1]
+      
+      - equal:
+          path: spec.template.spec.volumes[1]
+          value:
+            name: octopus-server-certificate-configmap
+            configMap:
+              name: "octopus-server-certificate"
+
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+          value:
+            name: octopus-server-certificate-configmap
+            mountPath: /etc/ssl/certs/octopus-server-certificate.pem
+            subPath: octopus-server-certificate.pem
+            readOnly: false

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -138,11 +138,10 @@ tests:
           path: metadata.name
           value: thisisaverylongstring34087236548972364802367y408923604872341234-tentacle
 
-  - it: "mounts octopus server certificate when encoded certificate provided"
+  - it: "mounts octopus server certificate when server certificate provided"
     set:
       agent:
-        serverCA:
-          encodedCertificate: "dGVzdC10ZXh0"
+        serverCertificate: "dGVzdC10ZXh0"
     asserts:
       - exists:
           path: spec.template.spec.volumes[1]

--- a/charts/kubernetes-agent/tests/tentacle-server-cert-configmap_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-server-cert-configmap_test.yaml
@@ -1,0 +1,16 @@
+suite: tentacle configuration
+templates:
+  - templates/tentacle-server-cert-configmap.yaml
+tests:
+  - it: "is not created if no encodedCertificate is provided"
+    asserts:
+    - hasDocuments:
+        count: 0        
+  - it: "matches snapshot"
+    set:
+      agent:
+        serverCA:
+          encodedCertificate: "dGVzdC10ZXh0"
+    asserts:
+      - matchSnapshot: {}
+

--- a/charts/kubernetes-agent/tests/tentacle-server-cert-configmap_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-server-cert-configmap_test.yaml
@@ -9,8 +9,7 @@ tests:
   - it: "matches snapshot"
     set:
       agent:
-        serverCA:
-          encodedCertificate: "dGVzdC10ZXh0"
+        serverCertificate: "dGVzdC10ZXh0"
     asserts:
       - matchSnapshot: {}
 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -18,14 +18,9 @@ agent:
   # -- The URL of the target Octopus Server to register this agent with
   # @section -- Agent values
   serverUrl: ""
-
-  # -- If the Octopus Server has a custom certificate, it's public key can be added here
+  # -- The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format.
   # @section -- Agent values
-  serverCA:
-    # -- The base64-encoded public certificate used by Octopus Server
-    # @section -- Agent values
-    encodedCertificate: ""
-
+  serverCertificate: ""
   # -- The polling communication URL of the target Octopus Server
   # @section -- Agent values
   serverCommsAddress: ""
@@ -59,7 +54,7 @@ agent:
   # -- The target tenant tags to register the agent with
   # @section -- Agent values
   targetTenantTags: []
-  # -- A base64 formatted x509 certificate used to setup a trust between the agent and target Octopus Server
+  # -- A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server
   # @section -- Agent values
   certificate: ""
   # -- The machine policy to register the agent with

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -79,7 +79,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1819"
+    tag: "8.1.1838"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -18,6 +18,14 @@ agent:
   # -- The URL of the target Octopus Server to register this agent with
   # @section -- Agent values
   serverUrl: ""
+
+  # -- If the Octopus Server has a custom certificate, it's public key can be added here
+  # @section -- Agent values
+  serverCA:
+    # -- The base64-encoded public certificate used by Octopus Server
+    # @section -- Agent values
+    encodedCertificate: ""
+
   # -- The polling communication URL of the target Octopus Server
   # @section -- Agent values
   serverCommsAddress: ""


### PR DESCRIPTION
Customers have reported issues where the agent cannot register due to the target Octopus Server having a custom or self-signed TLS certificate.

This PR adds support for this by adding a new value option.
```yaml
agent:
  serverCertificate: ""
```
When specified with an base64 encoded certificate, this mounts the certificate into `/etc/ssl/certs` using a configmap mount.

To support this, we also need the `kubernetes-agent-tentacle` docker container updated to perform a `openssl rehash /etc/ssl/certs` as the loaded certificate needs hashing before it can be used. This is coming in another PR: https://github.com/OctopusDeploy/OctopusTentacle/pull/967

This PR will also need the tentacle version updated when the above PR is merged