### PR TITLE
kubernetes-agent: Update nfs-watchdog version

### DIFF
--- a/.changeset/khaki-ways-admire.md
+++ b/.changeset/khaki-ways-admire.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": minor
 ---
 
-Update kubernetes-agent to use a newer nfs-watchdog which raises event on nfs timeout
+Update kubernetes-agent to use a nfs-watchdog v0.1.0 which raises event on nfs timeout

--- a/.changeset/khaki-ways-admire.md
+++ b/.changeset/khaki-ways-admire.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update kubernetes-agent to use a newer nfs-watchdog which raises event on nfs timeout

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -57,7 +57,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | persistence.nfs.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/nfs-server","tag":"1.0.1"}` | The repository, pullPolicy & tag to use for the NFS server |
 | persistence.nfs.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the NFS pod & container |
 | persistence.nfs.watchdog.enabled | bool | `true` | If enabled, the NFS watchdog will monitor NFS availability and restart Tentacle and Script Pods if the NFS server is unresponsive |
-| persistence.nfs.watchdog.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-nfs-watchdog","tag":"0.0.2"}` | The repository, pullPolicy & tag to use for the NFS watchdog |
+| persistence.nfs.watchdog.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-nfs-watchdog","tag":"0.1.0"}` | The repository, pullPolicy & tag to use for the NFS watchdog |
 | persistence.nfs.watchdog.initial_backoff_seconds | string | `""` | The initial backoff time in seconds to retry failed NFS checks @default 0.5 |
 | persistence.nfs.watchdog.loop_seconds | string | `""` | The frequency in seconds to check the NFS server @default 5 |
 | persistence.nfs.watchdog.timeout_seconds | string | `""` | The total time to retry failed NFS checks before giving up and deleting the pod @default 10 |

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -79,7 +79,7 @@ should match snapshot:
                 - name: OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP
                   value: "false"
                 - name: OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE
-                  value: octopusdeploy/kubernetes-agent-nfs-watchdog:0.0.2
+                  value: octopusdeploy/kubernetes-agent-nfs-watchdog:0.1.0
                 - name: OCTOPUS__TENTACLE__LOGLEVEL
                   value: Info
                 - name: TentacleHome
@@ -112,7 +112,7 @@ should match snapshot:
             - env:
                 - name: watchdog_directory
                   value: /octopus
-              image: octopusdeploy/kubernetes-agent-nfs-watchdog:0.0.2
+              image: octopusdeploy/kubernetes-agent-nfs-watchdog:0.1.0
               imagePullPolicy: IfNotPresent
               name: nfs-watchdog
               volumeMounts:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -176,7 +176,7 @@ persistence:
       image:
         repository: octopusdeploy/kubernetes-agent-nfs-watchdog
         pullPolicy: IfNotPresent
-        tag: "0.0.2"
+        tag: "0.1.0"
 
 # Used for integration testing to avoid registering with a real Octopus Server
 # @ignored


### PR DESCRIPTION
This updates the kubernetes helm chart to include the newer nfs-watchdog version which raises an event when an NFS timeout occurs.