### PR TITLE
Version Kubernetes Agent Chart

### DIFF
--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # kubernetes-agent
 
+## 2.0.0-alpha.0
+
+### Major Changes
+
+- 05fa04c: Creating Kubernetes Agent v2 alpha prerelease
+
 ## 1.7.0
 
 ### Minor Changes

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
     email: "support@octopus.com"
     url: "https://octopus.com"
 type: application
-version: "1.7.0"
+version: "2.0.0-alpha.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
 appVersion: "8.1.1838"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1838](https://img.shields.io/badge/AppVersion-8.1.1838-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.0.0-alpha.0](https://img.shields.io/badge/Version-2.0.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1838](https://img.shields.io/badge/AppVersion-8.1.1838-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 

--- a/charts/kubernetes-agent/package.json
+++ b/charts/kubernetes-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-agent",
-  "version": "1.7.0",
+  "version": "2.0.0-alpha.0",
   "private": true,
   "description": "The Octopus Kubernetes Agent",
   "author": "Octopus Deploy Ptd Ltd",

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -9,6 +9,6 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
         app.kubernetes.io/version: 8.1.1838
-        helm.sh/chart: kubernetes-agent-1.7.0
+        helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
         app.kubernetes.io/version: 8.1.1838
-        helm.sh/chart: kubernetes-agent-1.7.0
+        helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
             app.kubernetes.io/version: 8.1.1838
-            helm.sh/chart: kubernetes-agent-1.7.0
+            helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
         spec:
           affinity:
             nodeAffinity:
@@ -75,7 +75,7 @@ should match snapshot:
                 - name: OCTOPUS__K8STENTACLE__HELMRELEASENAME
                   value: RELEASE-NAME
                 - name: OCTOPUS__K8STENTACLE__HELMCHARTVERSION
-                  value: 1.7.0
+                  value: 2.0.0-alpha.0
                 - name: OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP
                   value: "false"
                 - name: OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
         app.kubernetes.io/version: 8.1.1838
-        helm.sh/chart: kubernetes-agent-1.7.0
+        helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:
       accessModes:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -9,6 +9,6 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
         app.kubernetes.io/version: 8.1.1838
-        helm.sh/chart: kubernetes-agent-1.7.0
+        helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE


### PR DESCRIPTION
This PR was manually created to make the initial v2 alpha version of the Kubernetes agent helm chart.

# Releases
## kubernetes-agent@2.0.0-alpha.0

### Major Changes

-    05fa04c Creating Kubernetes Agent v2 alpha prerelease