### PR TITLE
Remove redundant jobs from Kubernetes agent GHA

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -135,17 +135,3 @@ jobs:
         space: 'Modern Deployments'
         packages: ${{ needs.version_and_package.outputs.PACKAGE_NAME }}
         overwrite_mode: IgnoreIfExists
-
-  publish_artifactory:
-    runs-on: ubuntu-latest
-    if: false
-    steps:
-    - shell: bash
-      run: echo "no-op"
-
-  publish_dockerhub:
-    runs-on: ubuntu-latest
-    if: false
-    steps:
-    - shell: bash
-      run: echo "no-op"


### PR DESCRIPTION
# Background

These were required because we had required checks on them but now they can be removed.

[sc-82969]