### PR TITLE
Add release/kubernetes-agent/v* as a branch for GHAs

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - release/kubernetes-agent/v*
     paths:
     - charts/kubernetes-agent/**
     - .github/workflows/create-versioning-pr.yaml

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - release/kubernetes-agent/v*
 
   pull_request:
 


### PR DESCRIPTION
# Background

Now that we support release branches, we need the GHAs to trigger on pushes to them.

# Results

We just need to add these as branches to the GHAs.

[sc-82968]