### PR TITLE
Publish tag when a versioning commit merges

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -9,6 +9,29 @@ on:
     - .github/workflows/create-versioning-pr.yaml
     
 jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    # When a changesets generated Versioning PR is merged, we want to publish the version as a tag
+    if: ${{ startsWith(github.event.commits[0].message, 'Version Kubernetes Agent Chart') }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }} 
+    
+    - name: setup-node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - uses: pnpm/action-setup@v2.2.4
+      with:
+        version: 8.15.2
+        run_install: true
+
+    - name: Publish Version Tag
+      run: pnpm publish-version-tags
+
   version:
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "description": "The official Octopus helm charts",
     "scripts": {
         "changeset": "changeset",
-        "ci:version": "run changeset version && install"
+        "ci:version": "run changeset version && install",
+        "publish-version-tags": "pnpm changeset publish && git push --follow-tags"
     },
     "devDependencies": {
         "@changesets/cli": "^2.27.1"


### PR DESCRIPTION
# Background

We want to publish a tag with the version of the Kubernetes agent each time a Versioning PR is merged.

# Results

The versioning github action document will run a publish after the Versioning PR is merged to main.

Note: I can't really test this until we have a new Version to publish...