### PR TITLE
Update startup probe to increase reliability

### DIFF
--- a/.changeset/stale-wasps-do.md
+++ b/.changeset/stale-wasps-do.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Bump the failureThreshold to fix startup probe problems

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -38,6 +38,7 @@ spec:
                 - /etc/octopus/initialized
             initialDelaySeconds: 2
             periodSeconds: 2
+            failureThreshold: 100
           env:
             - name: "ACCEPT_EULA"
               value: {{ .Values.agent.acceptEula | quote }}

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -104,6 +104,7 @@ should match snapshot:
                   command:
                     - cat
                     - /etc/octopus/initialized
+                failureThreshold: 100
                 initialDelaySeconds: 2
                 periodSeconds: 2
               volumeMounts:


### PR DESCRIPTION
As per https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#probe-v1-core - the `failureThreshold` defaults to 3, meaning we waited a maximum of 8 seconds for the container to be ready until we marked it as failed. This PR specifically sets the `failureThreshold` to be 100, which should resolve this issue.