### PR TITLE
Add Create Release step to GHAs for Kubernetes Agent

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -135,3 +135,12 @@ jobs:
         space: 'Modern Deployments'
         packages: ${{ needs.version_and_package.outputs.PACKAGE_NAME }}
         overwrite_mode: IgnoreIfExists
+
+    - name: Create a release in Octopus Deploy 🐙
+      uses: OctopusDeploy/create-release-action@v3
+      with:
+        space: 'Modern Deployments'
+        project: 'Octopus Kubernetes Agent'
+        release_number: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        package_version: ${{ needs.version_and_package.outputs.CHART_VERSION }}
+        ignore_existing: true


### PR DESCRIPTION
We've setup the Deploy instance of Octopus to have two channels for the Kubernetes agent helm chart. Unfortunately ARC (Automatic Release Creation) for package pushes doesn't support multiple channels. This means that we are not currently automatically creating releases for pre-release packages.

To fix this, I'm going to turn off ARC and revert to creating releases manually after pushing the package.

👇 No Changeset is required because this is a fix to the Github Actions and not a functional change.