### PR TITLE
Add support for imagePullSecrets on script pods

### DIFF
--- a/.changeset/eleven-crabs-sell.md
+++ b/.changeset/eleven-crabs-sell.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Add support for using imagePullSecrets on script pods

--- a/.changeset/eleven-crabs-sell.md
+++ b/.changeset/eleven-crabs-sell.md
@@ -1,5 +1,5 @@
 ---
-"kubernetes-agent": patch
+"kubernetes-agent": minor
 ---
 
 Add support for using imagePullSecrets on script pods

--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Patch Changes
 
-- 9a97ae5: Update kubernetes-agent-tentacle to 8.1.1873. Includes fix to mkdir failing during container startup
+- 9a97ae5: Update kubernetes-agent-tentacle to 8.1.1858. Includes fix to mkdir failing during container startup
 
 ## 1.7.0
 

--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Patch Changes
 
-- 9a97ae5: Update kubernetes-agent-tentacle to 8.1.1858. Includes fix to mkdir failing during container startup
+- 9a97ae5: Update kubernetes-agent-tentacle to 8.1.1873. Includes fix to mkdir failing during container startup
 
 ## 1.7.0
 

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.7.3"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1873"
+appVersion: "8.1.1880"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.7.3"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1858"
+appVersion: "8.1.1873"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1873](https://img.shields.io/badge/AppVersion-8.1.1873-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1880](https://img.shields.io/badge/AppVersion-8.1.1880-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1873"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1880"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
 
 ## Maintainers
@@ -79,7 +79,7 @@ A Helm chart for the Octopus Kubernetes Agent
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| imagePullSecrets | list | `[]` | custom registry pullSecret<br> See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
+| imagePullSecrets | list | `[]` | custom registry pullSecret<br> See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod These are used for the tentacle and script pods |
 | nameOverride | string | `""` | Override the name of the app |
 
 ----------------------------------------------

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1858](https://img.shields.io/badge/AppVersion-8.1.1858-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1873](https://img.shields.io/badge/AppVersion-8.1.1873-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1858"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1873"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -94,6 +94,10 @@ spec:
               value: {{ .Values.agent.pollingConnectionCount | quote }}
             - name: "OCTOPUS__K8STENTACLE__ENABLEMETRICSCAPTURE"
               value: {{ .Values.agent.enableMetricsCapture| quote }}
+            {{- if .Values.imagePullSecrets }}
+            - name: "OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES"
+              value: {{ join "," .Values.imagePullSecrets | quote}}
+            {{- end }}
             {{- if .Values.agent.serverApiKey }}
             - name: "ServerApiKey"
               valueFrom:

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1873
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1873
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1873
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1873
+            app.kubernetes.io/version: 8.1.1880
             helm.sh/chart: kubernetes-agent-1.7.3
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1873
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1880
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1873
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1858
+            app.kubernetes.io/version: 8.1.1873
             helm.sh/chart: kubernetes-agent-1.7.3
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1858
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1873
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1873
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1873
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1873
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1873
         helm.sh/chart: kubernetes-agent-1.7.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -161,3 +161,11 @@ tests:
         secretKeyRef:
           key: bearer-token
           name: the-agent-name-lobster-tentacle-server-auth
+
+- it: "Sets environment variable if image pull secrets set"
+  set:
+    imagePullSecrets: ["secret-1", "secret-2"]
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES')].value
+        value: "secret-1,secret-2"

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -163,3 +163,13 @@ tests:
             mountPath: /etc/ssl/certs/octopus-server-certificate.pem
             subPath: octopus-server-certificate.pem
             readOnly: false
+  
+  - it: "adds image pulls secrets to deployment"
+    set:
+      imagePullSecrets: ["secret-1", "secret-2"]
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - secret-1
+            - secret-2

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -5,6 +5,7 @@ nameOverride: ""
 
 # -- custom registry pullSecret<br>
 # See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# These are used for the tentacle and script pods
 imagePullSecrets: []
 #   - name: "registry-secret-name"
 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -80,7 +80,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1873"
+    tag: "8.1.1880"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -80,7 +80,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1858"
+    tag: "8.1.1873"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
@@ -50,6 +50,10 @@
       <EmbeddedResource Include="Setup\Common\Certificates\Tentacle.pfx">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
+      <None Remove="Setup\docker-registry-credentials-secret.yaml" />
+      <EmbeddedResource Include="Setup\docker-registry-credentials-secret.yaml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </EmbeddedResource>
     </ItemGroup>
 
 </Project>

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
@@ -119,7 +119,7 @@ public class KubernetesAgentInstaller
             "--install",
             "--atomic",
             $"-f \"{valuesFilePath}\"",
-            hasRegistrySecret ? $"--set imagePullSecrets=\"{{{RegistrySecretName}}}\"" : null,
+            hasRegistrySecret ? $"--set imagePullSecrets[0].name=\"{RegistrySecretName}\"" : null,
             $"--version \"{chartVersion}\"",
             NamespaceFlag,
             KubeConfigFlag,

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Halibut;
 using Halibut.Diagnostics;
 using KubernetesAgent.Integration.Setup.Common;
+using Newtonsoft.Json;
 using Octopus.Client.Model;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Client.Retries;
@@ -43,17 +44,23 @@ public class KubernetesAgentInstaller
 
     public string Namespace => $"octopus-agent-{AgentName}";
 
+    const string RegistrySecretName = "docker-registry-secret";
+
     public Uri SubscriptionId { get; } = PollingSubscriptionIdGenerator.Generate();
 
     public async Task<TentacleClient> InstallAgent()
     {
         var listeningPort = BuildServerHalibutRuntimeAndListen();
         var valuesFilePath = await WriteValuesFile(listeningPort);
-        var arguments = BuildAgentInstallArguments(valuesFilePath);
 
         var sw = new Stopwatch();
         sw.Restart();
 
+        CreateNamespace();
+
+        var hasRegistrySecret = await AddDockerHubRegistryCredentialSecret(logger);
+        
+        var arguments = BuildAgentInstallArguments(valuesFilePath, hasRegistrySecret);
 
         var result = ProcessRunner.RunWithLogger(helmExePath, temporaryDirectory, logger, arguments);
         sw.Stop();
@@ -68,13 +75,12 @@ public class KubernetesAgentInstaller
         var thumbprint = await GetAgentThumbprint();
 
         logger.Information("Agent certificate thumbprint: {Thumbprint:l}", thumbprint);
-        
+
         ServerHalibutRuntime.Trust(thumbprint);
-        
+
         BuildTentacleClient(thumbprint);
-        
+
         return TentacleClient;
-        
     }
 
     async Task<string> WriteValuesFile(int listeningPort)
@@ -104,7 +110,7 @@ public class KubernetesAgentInstaller
         return valuesFilePath;
     }
 
-    string BuildAgentInstallArguments(string valuesFilePath)
+    string BuildAgentInstallArguments(string valuesFilePath, bool hasRegistrySecret)
     {
         var chartVersion = GetChartVersion();
         var args = new[]
@@ -113,8 +119,8 @@ public class KubernetesAgentInstaller
             "--install",
             "--atomic",
             $"-f \"{valuesFilePath}\"",
+            hasRegistrySecret ? $"--set imagePullSecrets=\"{{{RegistrySecretName}}}\"" : null,
             $"--version \"{chartVersion}\"",
-            "--create-namespace",
             NamespaceFlag,
             KubeConfigFlag,
             AgentName,
@@ -124,23 +130,70 @@ public class KubernetesAgentInstaller
         return string.Join(" ", args.WhereNotNull());
     }
 
+    void CreateNamespace()
+    {
+        var result = ProcessRunner.Run(kubeCtlExePath, temporaryDirectory, "create", "namespace", Namespace);
+
+        if (result.ExitCode != 0)
+        {
+            logger.Error("Failed to create namespace {Namespace}", Namespace);
+            throw new InvalidOperationException($"Failed to create namespace {Namespace}.");
+        }
+    }
+
+    async Task<bool> AddDockerHubRegistryCredentialSecret(ILogger logger)
+    {
+        var username = Environment.GetEnvironmentVariable("DockerHub_Username");
+        var password = Environment.GetEnvironmentVariable("DockerHub_Password");
+
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+        {
+            return false;
+        }
+
+        using var reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStreamFromPartialName("docker-registry-credentials-secret.yaml"));
+
+        var secretYaml = await reader.ReadToEndAsync();
+
+        var config = new Dictionary<string, object>
+        {
+            ["auths"] = new Dictionary<string, object>
+            {
+                ["https://index.docker.io/v1/"] = new
+                {
+                    username,
+                    password,
+                    auth = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"))
+                }
+            }
+        };
+
+        var configJson = JsonConvert.SerializeObject(config, Formatting.None);
+
+        secretYaml = secretYaml
+            .Replace("#{Name}", RegistrySecretName)
+            .Replace("#{Namespace}", Namespace)
+            .Replace("#{DockerConfigJson}", Convert.ToBase64String(Encoding.UTF8.GetBytes(configJson)));
+
+        var filePath = Path.Combine(temporaryDirectory.Directory.FullName, "docker-registry-credentials-secret.yaml");
+        await File.WriteAllTextAsync(filePath, secretYaml, Encoding.UTF8);
+
+        var result = ProcessRunner.RunWithLogger(kubeCtlExePath, temporaryDirectory, this.logger, "apply", $"-f {filePath}");
+        
+        if (result.ExitCode != 0)
+        {
+            logger.Error("Failed to create docker hub registry secret {SecretName}", RegistrySecretName);
+            throw new InvalidOperationException($"Failed to create docker hub registry secret {RegistrySecretName}.");
+        }
+
+        return true;
+    }
+
     static string GetChartVersion()
     {
         var customHelmChartVersion = Environment.GetEnvironmentVariable("KubernetesIntegrationTests_HelmChartVersion");
 
         return !string.IsNullOrWhiteSpace(customHelmChartVersion) ? customHelmChartVersion : "1.*.*";
-    }
-
-    static string? GetImageAndRepository(string? tentacleImageAndTag)
-    {
-        if (tentacleImageAndTag is null)
-            return null;
-
-        var parts = tentacleImageAndTag.Split(":");
-        var repo = parts[0];
-        var tag = parts[1];
-
-        return $"--set agent.image.repository=\"{repo}\" --set agent.image.tag=\"{tag}\"";
     }
 
     async Task<string> GetAgentThumbprint()
@@ -154,7 +207,7 @@ public class KubernetesAgentInstaller
             thumbprint = await result.StandardOutput.ReadToEndAsync();
             if (result.ExitCode != 0)
             {
-                logger.Error("Failed to load thumbprint. Exit code {ExitCode}", result.ExitCode); 
+                logger.Error("Failed to load thumbprint. Exit code {ExitCode}", result.ExitCode);
             }
 
             if (!string.IsNullOrWhiteSpace(thumbprint))
@@ -201,6 +254,7 @@ public class KubernetesAgentInstaller
 
         return ServerHalibutRuntime.Listen();
     }
+
     string NamespaceFlag => $"--namespace \"{Namespace}\"";
     string KubeConfigFlag => $"--kubeconfig \"{kubeConfigPath}\"";
 
@@ -208,7 +262,8 @@ public class KubernetesAgentInstaller
     {
         if (isAgentInstalled)
         {
-            var uninstallArgs = string.Join(" ",
+            var uninstallArgs = string.Join(
+                " ",
                 "uninstall",
                 KubeConfigFlag,
                 NamespaceFlag,

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
@@ -132,7 +132,7 @@ public class KubernetesAgentInstaller
 
     void CreateNamespace()
     {
-        var result = ProcessRunner.Run(kubeCtlExePath, temporaryDirectory, "create", "namespace", Namespace);
+        var result = ProcessRunner.Run(kubeCtlExePath, temporaryDirectory, "create", "namespace", Namespace, KubeConfigFlag);
 
         if (result.ExitCode != 0)
         {
@@ -178,7 +178,7 @@ public class KubernetesAgentInstaller
         var filePath = Path.Combine(temporaryDirectory.Directory.FullName, "docker-registry-credentials-secret.yaml");
         await File.WriteAllTextAsync(filePath, secretYaml, Encoding.UTF8);
 
-        var result = ProcessRunner.RunWithLogger(kubeCtlExePath, temporaryDirectory, this.logger, "apply", $"-f {filePath}");
+        var result = ProcessRunner.RunWithLogger(kubeCtlExePath, temporaryDirectory, this.logger, "apply", $"-f {filePath}", KubeConfigFlag);
         
         if (result.ExitCode != 0)
         {

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/docker-registry-credentials-secret.yaml
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/docker-registry-credentials-secret.yaml
@@ -1,0 +1,8 @@
+﻿apiVersion: v1
+kind: Secret
+metadata:
+  name: "#{Name}"
+  namespace: "#{Namespace}"
+data:
+  .dockerconfigjson: "#{DockerConfigJson}"
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Customers have requested a way to set image pull secrets on the script pods.

This PR adds this support by pass the set `imagePullSecrets` as a comma-separated string to a new tentacle environment variable `OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES`.

Related Tentacle PR: https://github.com/OctopusDeploy/OctopusTentacle/pull/971