### PR TITLE
Add support for polling proxy server

### DIFF
--- a/.changeset/famous-items-hang.md
+++ b/.changeset/famous-items-hang.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": minor
 ---
 
-Add support for polling proxy server
+Add support for polling proxy server via new `agent.pollingProxy` values

--- a/.changeset/famous-items-hang.md
+++ b/.changeset/famous-items-hang.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add support for polling proxy server

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.8.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1880"
+appVersion: "8.1.1890"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -34,7 +34,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
-| agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to connect to Octopus Server with |
+| agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to use for polling connections |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key use to authenticate with the target Octopus Server |
 | agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1880](https://img.shields.io/badge/AppVersion-8.1.1880-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1890](https://img.shields.io/badge/AppVersion-8.1.1890-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1880"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1890"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
 
 ## Maintainers
@@ -34,6 +34,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
+| agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to connect to Octopus Server with |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key use to authenticate with the target Octopus Server |
 | agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -125,6 +125,21 @@ spec:
             {{- end}}
             - name: "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE"
               value: {{ .Values.persistence.size | quote }}
+            {{- if .Values.agent.pollingProxy.host }}
+            - name: "TentaclePollingProxyHost"
+              value: {{ .Values.agent.pollingProxy.host | quote }}
+            - name: "TentaclePollingProxyPort"
+              value: {{ .Values.agent.pollingProxy.port }}
+            - name: "TentaclePollingProxyUsername"
+              value: {{ .Values.agent.pollingProxy.username | quote }}              
+            {{- if .Values.agent.pollingProxy.password }}
+            - name: "TentaclePollingProxyPassword"
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
+                  key: polling-proxy-password
+            {{- end }}            
+            {{- end }}
           {{- with .Values.agent.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -12,5 +12,5 @@ data:
   api-key: {{ . | b64enc }}
 {{- end }}
 {{- with .Values.agent.pollingProxy.password }}
-  polling-proxy-password: {{. | b64enc }}
+  polling-proxy-password: {{ . | b64enc }}
 {{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -11,3 +11,6 @@ data:
 {{- with .Values.agent.serverApiKey }}
   api-key: {{ . | b64enc }}
 {{- end }}
+{{- with .Values.agent.pollingProxy.password }}
+  polling-proxy-password: {{. | b64enc }}
+{{- end }}

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1880
+        app.kubernetes.io/version: 8.1.1890
         helm.sh/chart: kubernetes-agent-1.8.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1880
+        app.kubernetes.io/version: 8.1.1890
         helm.sh/chart: kubernetes-agent-1.8.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1880
+            app.kubernetes.io/version: 8.1.1890
             helm.sh/chart: kubernetes-agent-1.8.0
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1880
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1890
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1880
+        app.kubernetes.io/version: 8.1.1890
         helm.sh/chart: kubernetes-agent-1.8.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1880
+        app.kubernetes.io/version: 8.1.1890
         helm.sh/chart: kubernetes-agent-1.8.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -162,6 +162,60 @@ tests:
           key: bearer-token
           name: the-agent-name-lobster-tentacle-server-auth
 
+- it: "sets polling proxy information if host ifs specified"
+  set:
+    agent:
+      pollingProxy:
+        host: "example.com"
+        port: 1234
+        username: "user"
+        password: "pw-1234"
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyHost')].value
+      value: "example.com"
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPort')].value
+      value: 1234
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyUsername')].value
+      value: "user"
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPassword')].valueFrom
+      value: 
+        secretKeyRef:
+          key: polling-proxy-password
+          name: octopus-agent-tentacle-server-auth
+
+- it: "does not include polling proxy information if host is not specified"
+  set:
+    agent:
+      pollingProxy:
+        port: 1234
+        username: "user"
+        password: "pw-1234"
+  asserts:
+  - notExists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyHost')]
+  - notExists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPort')]
+  - notExists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyUsername')]
+  - notExists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPassword')]
+
+- it: "does not include polling proxy password if not specified"
+  set:
+    agent:
+      pollingProxy:
+        host: example.com
+        password: "pw-1234"
+  asserts:
+  - exists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyHost')]
+  - exists:
+      path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPassword')]
+
 - it: "Sets environment variable if image pull secrets set"
   set:
     imagePullSecrets: ["secret-1", "secret-2"]

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -209,11 +209,10 @@ tests:
     agent:
       pollingProxy:
         host: example.com
-        password: "pw-1234"
   asserts:
   - exists:
       path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyHost')]
-  - exists:
+  - notExists:
       path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPassword')]
 
 - it: "Sets environment variable if image pull secrets set"

--- a/charts/kubernetes-agent/tests/tentacle-server-auth-secret_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-server-auth-secret_test.yaml
@@ -23,3 +23,12 @@ tests:
   - equal:
       path: data.api-key
       value: QVBJS0VZLWJsa2Fkc2pmbGRzamZsa3Nk
+- it: "sets polling-proxy-password if specified"
+  set:
+    agent:
+      pollingProxy:
+        password: "abc-123"
+  asserts:
+  - equal:
+      path: data.polling-proxy-password
+      value: YWJjLTEyMw==

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -75,6 +75,14 @@ agent:
   # @section -- Agent values
   enableMetricsCapture: true
 
+  # -- The host, port, username and password of the proxy server to connect to Octopus Server with
+  # @section -- Agent values
+  pollingProxy:
+    host: ""
+    port: 80
+    username: ""
+    password: ""
+
   # -- The repository, pullPolicy & tag to use for the agent image
   # @section -- Agent values
   image:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -88,7 +88,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1880"
+    tag: "8.1.1890"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -75,7 +75,7 @@ agent:
   # @section -- Agent values
   enableMetricsCapture: true
 
-  # -- The host, port, username and password of the proxy server to connect to Octopus Server with
+  # -- The host, port, username and password of the proxy server to use for polling connections
   # @section -- Agent values
   pollingProxy:
     host: ""


### PR DESCRIPTION
We had a customer ask if we supported the polling proxies in the Kubernetes agent.

Coupled with the changes in Tentacle PR: https://github.com/OctopusDeploy/OctopusTentacle/pull/975