### PR TITLE
Change integration tests to use Artifactory

### DIFF
--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesAgentInstaller.cs
@@ -131,18 +131,6 @@ public class KubernetesAgentInstaller
         return !string.IsNullOrWhiteSpace(customHelmChartVersion) ? customHelmChartVersion : "1.*.*";
     }
 
-    static string? GetImageAndRepository(string? tentacleImageAndTag)
-    {
-        if (tentacleImageAndTag is null)
-            return null;
-
-        var parts = tentacleImageAndTag.Split(":");
-        var repo = parts[0];
-        var tag = parts[1];
-
-        return $"--set agent.image.repository=\"{repo}\" --set agent.image.tag=\"{tag}\"";
-    }
-
     async Task<string> GetAgentThumbprint()
     {
         string? thumbprint = null;

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/agent-values.yaml
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/agent-values.yaml
@@ -8,6 +8,17 @@ agent:
   targetEnvironments: ["development"]
   targetRoles: ["testing-cluster"]
   
+  image:
+    repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-tentacle
+
+persistence:
+  nfs:
+    image:
+      repository: docker.packages.octopushq.com/octopusdeploy/nfs-server
+    watchdog:
+      image:
+        repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-nfs-watchdog
+        
 testing:
   tentacle:
     configMap:


### PR DESCRIPTION
We are having issues executing these tests due to the change to remove the Docker Hub rate limiting exemption for azure-hosted resources