### PR TITLE
Forward merge from release/kubernetes-agent/v1

### DIFF
--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - 05fa04c: Creating Kubernetes Agent v2 alpha prerelease
 
+## 1.8.0
+
+### Minor Changes
+
+- 34ce133: Add support for using imagePullSecrets on script pods
+
 ## 1.7.3
 
 ### Patch Changes

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "2.0.0-alpha.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1858"
+appVersion: "8.1.1880"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 2.0.0-alpha.0](https://img.shields.io/badge/Version-2.0.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1858](https://img.shields.io/badge/AppVersion-8.1.1858-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.0.0-alpha.0](https://img.shields.io/badge/Version-2.0.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1880](https://img.shields.io/badge/AppVersion-8.1.1880-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -29,7 +29,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1858"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1880"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
@@ -79,7 +79,7 @@ A Helm chart for the Octopus Kubernetes Agent
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| imagePullSecrets | list | `[]` | custom registry pullSecret<br> See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
+| imagePullSecrets | list | `[]` | custom registry pullSecret<br> See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod These are used for the tentacle and script pods |
 | nameOverride | string | `""` | Override the name of the app |
 
 ----------------------------------------------

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -94,6 +94,10 @@ spec:
               value: {{ .Values.agent.pollingConnectionCount | quote }}
             - name: "OCTOPUS__K8STENTACLE__ENABLEMETRICSCAPTURE"
               value: {{ .Values.agent.enableMetricsCapture| quote }}
+            {{- if .Values.imagePullSecrets }}
+            - name: "OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES"
+              value: {{ join "," .Values.imagePullSecrets | quote}}
+            {{- end }}
             {{- if .Values.agent.serverApiKey }}
             - name: "ServerApiKey"
               valueFrom:

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1858
+            app.kubernetes.io/version: 8.1.1880
             helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
         spec:
           affinity:
@@ -92,7 +92,7 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1858
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1880
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1858
+        app.kubernetes.io/version: 8.1.1880
         helm.sh/chart: kubernetes-agent-2.0.0-alpha.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -161,3 +161,11 @@ tests:
         secretKeyRef:
           key: bearer-token
           name: the-agent-name-lobster-tentacle-server-auth
+
+- it: "Sets environment variable if image pull secrets set"
+  set:
+    imagePullSecrets: ["secret-1", "secret-2"]
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES')].value
+        value: "secret-1,secret-2"

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -163,3 +163,13 @@ tests:
             mountPath: /etc/ssl/certs/octopus-server-certificate.pem
             subPath: octopus-server-certificate.pem
             readOnly: false
+  
+  - it: "adds image pulls secrets to deployment"
+    set:
+      imagePullSecrets: ["secret-1", "secret-2"]
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - secret-1
+            - secret-2

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -5,6 +5,7 @@ nameOverride: ""
 
 # -- custom registry pullSecret<br>
 # See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# These are used for the tentacle and script pods
 imagePullSecrets: []
 #   - name: "registry-secret-name"
 
@@ -79,7 +80,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1858"
+    tag: "8.1.1880"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/KubernetesAgent.IntegrationTests.csproj
@@ -50,6 +50,10 @@
       <EmbeddedResource Include="Setup\Common\Certificates\Tentacle.pfx">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
+      <None Remove="Setup\docker-registry-credentials-secret.yaml" />
+      <EmbeddedResource Include="Setup\docker-registry-credentials-secret.yaml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </EmbeddedResource>
     </ItemGroup>
 
 </Project>

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/agent-values.yaml
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/agent-values.yaml
@@ -8,17 +8,6 @@ agent:
   targetEnvironments: ["development"]
   targetRoles: ["testing-cluster"]
   
-  image:
-    repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-tentacle
-
-persistence:
-  nfs:
-    image:
-      repository: docker.packages.octopushq.com/octopusdeploy/nfs-server
-    watchdog:
-      image:
-        repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-nfs-watchdog
-        
 testing:
   tentacle:
     configMap:

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/docker-registry-credentials-secret.yaml
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/docker-registry-credentials-secret.yaml
@@ -1,0 +1,8 @@
+﻿apiVersion: v1
+kind: Secret
+metadata:
+  name: "#{Name}"
+  namespace: "#{Namespace}"
+data:
+  .dockerconfigjson: "#{DockerConfigJson}"
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Includes the new support for imagePullSecrets (#214)
Also reverts #217 as it's not necessary (or desired) anymore