### PR TITLE
Add serviceName to NFS StatefulSet

### DIFF
--- a/.changeset/dry-feet-add.md
+++ b/.changeset/dry-feet-add.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Correctly set serviceName on NFS StatefulSet

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ include "nfs.name" .}}
+  {{- if .Release.IsInstall }}
+  serviceName: {{ include "nfs.name" .}}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.persistence.nfs.metadata.annotations }}

--- a/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/nfs-statefulset_test.yaml.snap
@@ -11,6 +11,7 @@ should match snapshot:
       selector:
         matchLabels:
           app.kubernetes.io/name: octopus-agent-nfs
+      serviceName: octopus-agent-nfs
       template:
         metadata:
           labels:

--- a/charts/kubernetes-agent/tests/nfs-statefulset_test.yaml
+++ b/charts/kubernetes-agent/tests/nfs-statefulset_test.yaml
@@ -22,3 +22,18 @@ tests:
   - equal:
       path: spec.template.spec.volumes[?(@.name == 'octopus-volume')].emptyDir.sizeLimit
       value: 100Gi
+
+- it: does not set serviceName if Release.IsInstall is false
+  release:
+    upgrade: true
+  asserts:
+  - notExists:
+      path: spec.serviceName
+
+- it: sets serviceName if Release.IsInstall is true
+  release:
+    upgrade: false
+  asserts:
+  - equal:
+      path: spec.serviceName
+      value: octopus-agent-nfs


### PR DESCRIPTION
When using a `StatefulSet` with a headless service, you are supposed to set the `spec.serviceName` value. We weren't.

However, once a stateful set is created, this value can't be modified. As a result. I'm using the `.Release.IsInstall` flag to only set the `spec.serviceName` value when the agent is being created for the first time.

Not setting this value isn't a big issue because we don't have multiple replica's of the NFS pods