### PR TITLE
Fix the mapping of imagePullSecrets to a CSV list

### DIFF
--- a/.changeset/small-panthers-walk.md
+++ b/.changeset/small-panthers-walk.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Fix an issue with imagePullSecrets not being serialized in environment variables correctly

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -103,3 +103,16 @@ The name of the PersistentVolumeClaim to configure
 {{- include "nfs.pvcName" . }}
 {{- end }}
 {{- end }}
+
+{{/* 
+Turns the imagePullSecrets map into a CSV.
+*/}}
+{{- define "kubernetes-agent.imagePullSecretsCsv" -}}
+{{- if .Values.imagePullSecrets }}
+{{- $imagePullSecretCsv := (first .Values.imagePullSecrets).name }}
+{{- range $i, $val := (rest .Values.imagePullSecrets) }}
+    {{- $imagePullSecretCsv = (printf "%s,%s" $imagePullSecretCsv $val.name) }}
+{{- end }}
+{{- $imagePullSecretCsv }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               value: {{ .Values.agent.enableMetricsCapture| quote }}
             {{- if .Values.imagePullSecrets }}
             - name: "OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES"
-              value: {{ join "," .Values.imagePullSecrets | quote}}
+              value: {{ include "kubernetes-agent.imagePullSecretsCsv" . | quote }}
             {{- end }}
             - name: "OCTOPUS__K8STENTACLE__PODRESOURCEJSON"
               value: {{ .Values.scriptPods.resources | toJson | quote }}

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -215,13 +215,24 @@ tests:
   - notExists:
       path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPassword')]
 
-- it: "Sets environment variable if image pull secrets set"
+- it: "Sets environment variable if multiple image pull secrets set"
   set:
-    imagePullSecrets: ["secret-1", "secret-2"]
+    imagePullSecrets:
+    - name: secret-1
+    - name: secret-2
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES')].value
         value: "secret-1,secret-2"
+
+- it: "Sets environment variable if single image pull secret"
+  set:
+    imagePullSecrets:
+    - name: secret-1
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES')].value
+        value: "secret-1"
 
 
 - it: "Sets resource json if script pods resources changed"

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -166,10 +166,12 @@ tests:
   
   - it: "adds image pulls secrets to deployment"
     set:
-      imagePullSecrets: ["secret-1", "secret-2"]
+      imagePullSecrets:
+      - name: secret-1
+      - name: secret-2
     asserts:
       - equal:
           path: spec.template.spec.imagePullSecrets
           value:
-            - secret-1
-            - secret-2
+            - name: secret-1
+            - name: secret-2


### PR DESCRIPTION
I made a mistake with the `imagePullSecrets` and serializing this value to the CSV list that the tentacle code expects. This was also compounded by the fact the unit tests weren't correctly configuring the `imagePullSecrets` test values.