### PR TITLE
Add ability to use existing secrets to provide auth info

### DIFF
--- a/.changeset/mean-lobsters-explain.md
+++ b/.changeset/mean-lobsters-explain.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ability to use existing secrets to provide auth info

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.12.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1974"
+appVersion: "8.1.1979"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1974](https://img.shields.io/badge/AppVersion-8.1.1974-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1979](https://img.shields.io/badge/AppVersion-8.1.1979-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -31,7 +31,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1974"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1979"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -25,7 +25,8 @@ A Helm chart for the Octopus Kubernetes Agent
 |-----|------|---------|-------------|
 | agent.acceptEula | string | `"N"` | Setting to Y accepts the [Customer Agreement](https://octopus.com/company/legal) |
 | agent.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the agent pod |
-| agent.bearerToken | string | `""` | A JWT bearer token use to authenticate with the target Octopus Server |
+| agent.bearerToken | string | `""` | A JWT bearer token used to authenticate with the target Octopus Server |
+| agent.bearerTokenSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in the `bearer-token` key. |
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
@@ -34,10 +35,12 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
+| agent.password | string | `""` | The password of the user used to authenticate with the target Octopus Server |
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
 | agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to use for polling connections |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
-| agent.serverApiKey | string | `""` | An Octopus Server API key use to authenticate with the target Octopus Server |
+| agent.serverApiKey | string | `""` | An Octopus Server API key used to authenticate with the target Octopus Server |
+| agent.serverApiKeySecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in the `api-key` key. |
 | agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |
 | agent.serverCommsAddress | string | `""` | The polling communication URL of the target Octopus Server |
 | agent.serverCommsAddresses | list | `[]` | The polling communication URLs of the target Octopus Servers when running in High Availability (HA) |
@@ -53,6 +56,8 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.targetTenantedDeploymentParticipation | string | `"Untenanted"` | Can be `Untenanted`, `TenantedOrUntenanted` or `Tenanted`. |
 | agent.targetTenants | list | `[]` | The target tenants to register the agent with |
 | agent.tolerations | list | `[]` | The tolerations to apply to the agent pod |
+| agent.username | string | `""` | The username of the user used to authenticate with the target Octopus Server |
+| agent.usernamePasswordSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in the `username` and `password` keys. |
 
 ### Persistence
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -26,7 +26,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.acceptEula | string | `"N"` | Setting to Y accepts the [Customer Agreement](https://octopus.com/company/legal) |
 | agent.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the agent pod |
 | agent.bearerToken | string | `""` | A JWT bearer token used to authenticate with the target Octopus Server |
-| agent.bearerTokenSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token`. |
+| agent.bearerTokenSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token` in secret. |
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
@@ -40,7 +40,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to use for polling connections |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key used to authenticate with the target Octopus Server |
-| agent.serverApiKeySecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key`. |
+| agent.serverApiKeySecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key` in secret. |
 | agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |
 | agent.serverCommsAddress | string | `""` | The polling communication URL of the target Octopus Server |
 | agent.serverCommsAddresses | list | `[]` | The polling communication URLs of the target Octopus Servers when running in High Availability (HA) |
@@ -57,7 +57,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.targetTenants | list | `[]` | The target tenants to register the agent with |
 | agent.tolerations | list | `[]` | The tolerations to apply to the agent pod |
 | agent.username | string | `""` | The username of the user used to authenticate with the target Octopus Server |
-| agent.usernamePasswordSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password`. |
+| agent.usernamePasswordSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password` in secret. |
 
 ### Persistence
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -26,7 +26,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.acceptEula | string | `"N"` | Setting to Y accepts the [Customer Agreement](https://octopus.com/company/legal) |
 | agent.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the agent pod |
 | agent.bearerToken | string | `""` | A JWT bearer token used to authenticate with the target Octopus Server |
-| agent.bearerTokenSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in the `bearer-token` key. |
+| agent.bearerTokenSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token`. |
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
@@ -40,7 +40,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to use for polling connections |
 | agent.resources | object | `{"requests":{"cpu":"100m","memory":"150Mi"}}` | The resource limits and requests assigned to the agent container |
 | agent.serverApiKey | string | `""` | An Octopus Server API key used to authenticate with the target Octopus Server |
-| agent.serverApiKeySecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in the `api-key` key. |
+| agent.serverApiKeySecretName | string | `""` | The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key`. |
 | agent.serverCertificate | string | `""` | The base64-encoded public x509 certificate used by the target Octopus Server. Must be in the PEM/CER format. |
 | agent.serverCommsAddress | string | `""` | The polling communication URL of the target Octopus Server |
 | agent.serverCommsAddresses | list | `[]` | The polling communication URLs of the target Octopus Servers when running in High Availability (HA) |
@@ -57,7 +57,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.targetTenants | list | `[]` | The target tenants to register the agent with |
 | agent.tolerations | list | `[]` | The tolerations to apply to the agent pod |
 | agent.username | string | `""` | The username of the user used to authenticate with the target Octopus Server |
-| agent.usernamePasswordSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in the `username` and `password` keys. |
+| agent.usernamePasswordSecretName | string | `""` | The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password`. |
 
 ### Persistence
 

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -109,19 +109,33 @@ spec:
             - name: "OCTOPUS__K8STENTACLE__PODTOLERATIONSJSON"
               value: {{ .| toJson | quote }}
             {{- end }}
-            {{- if .Values.agent.serverApiKey }}
+            {{- if or .Values.agent.serverApiKey .Values.agent.serverApiKeySecretName }}
             - name: "ServerApiKey"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
+                  name: {{ .Values.agent.serverApiKeySecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: api-key
             {{- end }}
-            {{- if .Values.agent.bearerToken }}
+            {{- if or .Values.agent.bearerToken .Values.agent.bearerTokenSecretName  }}
             - name: "BearerToken"
               valueFrom:
                 secretKeyRef: 
-                  name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
+                  name: {{ .Values.agent.bearerTokenSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: bearer-token
+            {{- end }}
+            {{- if or .Values.agent.username .Values.agent.usernamePasswordSecretName }}
+            - name: "ServerUsername"
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
+                  key: username
+            {{- end }}
+            {{- if or .Values.agent.password .Values.agent.usernamePasswordSecretName }}
+            - name: "ServerPassword"
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
+                  key: password
             {{- end }}
             {{- if .Values.agent.certificate }}
             - name: "TentacleCertificateBase64"

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,11 +6,19 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
+{{- if and (not .Values.agent.bearerTokenSecretName) (not .Values.agent.serverApiKeySecretName) (not .Values.agent.usernamePasswordSecretName) }}
 {{- with .Values.agent.bearerToken }}
   bearer-token: {{ . | b64enc }}
 {{- end }}  
 {{- with .Values.agent.serverApiKey }}
   api-key: {{ . | b64enc }}
+{{- end }}
+{{- with .Values.agent.username }}
+  username: {{. | b64enc }}
+{{- end }}
+{{- with .Values.agent.password }}
+  password: {{. | b64enc }}
+{{- end }}
 {{- end }}
 {{- with .Values.agent.pollingProxy.password }}
   polling-proxy-password: {{ . | b64enc }}

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -14,10 +14,10 @@ data:
   api-key: {{ . | b64enc }}
 {{- end }}
 {{- with .Values.agent.username }}
-  username: {{. | b64enc }}
+  username: {{ . | b64enc }}
 {{- end }}
 {{- with .Values.agent.password }}
-  password: {{. | b64enc }}
+  password: {{ . | b64enc }}
 {{- end }}
 {{- end }}
 {{- with .Values.agent.pollingProxy.password }}

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1974
+        app.kubernetes.io/version: 8.1.1979
         helm.sh/chart: kubernetes-agent-1.12.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1974
+        app.kubernetes.io/version: 8.1.1979
         helm.sh/chart: kubernetes-agent-1.12.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1974
+            app.kubernetes.io/version: 8.1.1979
             helm.sh/chart: kubernetes-agent-1.12.0
         spec:
           affinity:
@@ -98,7 +98,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1974
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1979
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1974
+        app.kubernetes.io/version: 8.1.1979
         helm.sh/chart: kubernetes-agent-1.12.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1974
+        app.kubernetes.io/version: 8.1.1979
         helm.sh/chart: kubernetes-agent-1.12.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -149,6 +149,19 @@ tests:
           key: api-key
           name: the-agent-name-lobster-tentacle-server-auth
 
+- it: "Uses the existing server API key secret name if specified"
+  set:
+    agent:
+      serverApiKey: APIKEY-blkadsjfldsjflksd
+      serverApiKeySecretName: myCoolSecretName
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'ServerApiKey')].valueFrom
+      value: 
+        secretKeyRef:
+          key: api-key
+          name: myCoolSecretName
+
 - it: "Sets bearer token if specified"
   set:
     nameOverride: the-agent-name-lobster
@@ -161,6 +174,68 @@ tests:
         secretKeyRef:
           key: bearer-token
           name: the-agent-name-lobster-tentacle-server-auth
+
+- it: "Uses existing bearer token secret name if specified"
+  set:
+    nameOverride: the-agent-name-lobster
+    agent:
+      bearerToken: fkadjsgfjkaeuwygfkuwyafgu3gwfkua36wgfu3wgkujafghj
+      bearerTokenSecretName: myCoolSecretName
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'BearerToken')].valueFrom
+      value: 
+        secretKeyRef:
+          key: bearer-token
+          name: myCoolSecretName
+
+- it: "Sets username if specified"
+  set:
+    nameOverride: the-agent-name-lobster
+    agent:
+      username: "user-name"
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'ServerUsername')].valueFrom
+      value: 
+        secretKeyRef:
+          key: username
+          name: the-agent-name-lobster-tentacle-server-auth
+
+- it: "Sets password if specified"
+  set:
+    nameOverride: the-agent-name-lobster
+    agent:
+      password: "password-1"
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'ServerPassword')].valueFrom
+      value: 
+        secretKeyRef:
+          key: password
+          name: the-agent-name-lobster-tentacle-server-auth
+
+- it: "Sets username if specified"
+  set:
+    nameOverride: the-agent-name-lobster
+    agent:
+      username: "user-name"
+      password: "password-1"
+      usernamePasswordSecretName: "myCoolSecretName"
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'ServerUsername')].valueFrom
+      value: 
+        secretKeyRef:
+          key: username
+          name: myCoolSecretName
+  - equal:
+      path: spec.template.spec.containers[0].env[?(@.name == 'ServerPassword')].valueFrom
+      value: 
+        secretKeyRef:
+          key: password
+          name: myCoolSecretName
+
 
 - it: "sets polling proxy information if host ifs specified"
   set:

--- a/charts/kubernetes-agent/tests/tentacle-server-auth-secret_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-server-auth-secret_test.yaml
@@ -32,3 +32,71 @@ tests:
   - equal:
       path: data.polling-proxy-password
       value: YWJjLTEyMw==
+- it: "sets username if specified"
+  set:
+    agent:
+      username: "user-1"
+  asserts:
+  - equal:
+      path: data.username
+      value: dXNlci0x
+- it: "sets password if specified"
+  set:
+    agent:
+      password: "my-cool-password"
+  asserts:
+  - equal:
+      path: data.password
+      value: bXktY29vbC1wYXNzd29yZA==
+
+- it: "doesn't include auth if existing bearer token secret used"
+  set:
+    agent:
+      bearerToken: "token1"
+      serverApiKey: "key -1"
+      username: "user-1"
+      password: "my-cool-password"
+      bearerTokenSecretName: "myExistingSecret"
+  asserts:
+  - notExists:
+      path: data.bearer-token
+  - notExists:
+      path: data.api-key
+  - notExists:
+      path: data.username
+  - notExists:
+      path: data.password
+- it: "doesn't include auth if existing api key secret used"
+  set:
+    agent:
+      bearerToken: "token1"
+      serverApiKey: "key -1"
+      username: "user-1"
+      password: "my-cool-password"
+      serverApiKeySecretName: "myExistingSecret"
+  asserts:
+  - notExists:
+      path: data.bearer-token
+  - notExists:
+      path: data.api-key
+  - notExists:
+      path: data.username
+  - notExists:
+      path: data.password
+- it: "doesn't include auth if existing username/password secret used"
+  set:
+    agent:
+      bearerToken: "token1"
+      serverApiKey: "key -1"
+      username: "user-1"
+      password: "my-cool-password"
+      usernamePasswordSecretName: "myExistingSecret"
+  asserts:
+  - notExists:
+      path: data.bearer-token
+  - notExists:
+      path: data.api-key
+  - notExists:
+      path: data.username
+  - notExists:
+      path: data.password

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -34,13 +34,13 @@ agent:
   # -- A JWT bearer token used to authenticate with the target Octopus Server
   # @section -- Agent values
   bearerToken: ""
-  # -- The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token`.
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token` in secret.
   # @section -- Agent values
   bearerTokenSecretName: ""
   # -- An Octopus Server API key used to authenticate with the target Octopus Server
   # @section -- Agent values
   serverApiKey: ""
-  # -- The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key`.
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key` in secret.
   # @section -- Agent values
   serverApiKeySecretName: ""
   # -- The username of the user used to authenticate with the target Octopus Server
@@ -49,7 +49,7 @@ agent:
   # -- The password of the user used to authenticate with the target Octopus Server
   # @section -- Agent values
   password: ""  
-  # -- The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password`.
+  # -- The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password` in secret.
   # @section -- Agent values
   usernamePasswordSecretName: ""
   # -- The Space to register the agent in

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -103,7 +103,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1974"
+    tag: "8.1.1979"
    
   serviceAccount:
     # -- The name of the service account for the agent pod

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -34,13 +34,13 @@ agent:
   # -- A JWT bearer token used to authenticate with the target Octopus Server
   # @section -- Agent values
   bearerToken: ""
-  # -- The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in the `bearer-token` key.
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in `data.bearer-token`.
   # @section -- Agent values
   bearerTokenSecretName: ""
   # -- An Octopus Server API key used to authenticate with the target Octopus Server
   # @section -- Agent values
   serverApiKey: ""
-  # -- The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in the `api-key` key.
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in `data.api-key`.
   # @section -- Agent values
   serverApiKeySecretName: ""
   # -- The username of the user used to authenticate with the target Octopus Server
@@ -49,7 +49,7 @@ agent:
   # -- The password of the user used to authenticate with the target Octopus Server
   # @section -- Agent values
   password: ""  
-  # -- The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in the `username` and `password` keys.
+  # -- The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in `data.username` and `data.password`.
   # @section -- Agent values
   usernamePasswordSecretName: ""
   # -- The Space to register the agent in

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -31,12 +31,27 @@ agent:
   # -- The subscription ID that is used to by the agent to identify itself with Octopus Server
   # @section -- Agent values
   serverSubscriptionId: ""
-  # -- A JWT bearer token use to authenticate with the target Octopus Server
+  # -- A JWT bearer token used to authenticate with the target Octopus Server
   # @section -- Agent values
   bearerToken: ""
-  # -- An Octopus Server API key use to authenticate with the target Octopus Server
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server JWT bearer token. Value must be set in the `bearer-token` key.
+  # @section -- Agent values
+  bearerTokenSecretName: ""
+  # -- An Octopus Server API key used to authenticate with the target Octopus Server
   # @section -- Agent values
   serverApiKey: ""
+  # -- The name of an existing Secret that contains a base64-encoded Octopus Server API Key.  Value must be set in the `api-key` key.
+  # @section -- Agent values
+  serverApiKeySecretName: ""
+  # -- The username of the user used to authenticate with the target Octopus Server
+  # @section -- Agent values
+  username: ""
+  # -- The password of the user used to authenticate with the target Octopus Server
+  # @section -- Agent values
+  password: ""  
+  # -- The name of an existing Secret that contains a base64-encoded username and password for an Octopus Server user. Values must be set in the `username` and `password` keys.
+  # @section -- Agent values
+  usernamePasswordSecretName: ""
   # -- The Space to register the agent in
   # @section -- Agent values
   space: "Default"


### PR DESCRIPTION
Fixes #228 

Enables the ability to BYO an existing secret that contains an existing bearer token, server api key or username/password.

If you specify an existing secret name, any defined bearer token/apikey/username/password are ignored