### PR TITLE
Add ability to modify agent, nfs and script pod affinity and tolerations

### DIFF
--- a/.changeset/sharp-elephants-bathe.md
+++ b/.changeset/sharp-elephants-bathe.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ability to modify agent, nfs and script pod affinity and tolerations

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.10.3"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.1948"
+appVersion: "8.1.1974"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
 
 ## Maintainers
@@ -24,6 +24,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | agent.acceptEula | string | `"N"` | Setting to Y accepts the [Customer Agreement](https://octopus.com/company/legal) |
+| agent.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the agent pod |
 | agent.bearerToken | string | `""` | A JWT bearer token use to authenticate with the target Octopus Server |
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
@@ -51,6 +52,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.targetTenantTags | list | `[]` | The target tenant tags to register the agent with |
 | agent.targetTenantedDeploymentParticipation | string | `"Untenanted"` | Can be `Untenanted`, `TenantedOrUntenanted` or `Tenanted`. |
 | agent.targetTenants | list | `[]` | The target tenants to register the agent with |
+| agent.tolerations | list | `[]` | The tolerations to apply to the agent pod |
 
 ### Persistence
 
@@ -70,12 +72,14 @@ A Helm chart for the Octopus Kubernetes Agent
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.resources | object | `{"requests":{"cpu":"25m","memory":"100Mi"}}` | The resource limits and requests assigned to script pod containers |
 | scriptPods.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | scriptPods.serviceAccount.clusterRole | object | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]},{"nonResourceURLs":["*"],"verbs":["*"]}]` | if defined, overrides the default ClusterRole rules |
 | scriptPods.serviceAccount.name | string | `""` | The name of the service account used for executing script pods |
 | scriptPods.serviceAccount.targetNamespaces | list | Uses a ClusterRoleBinding to allow the service account to run in any namespace | Specifies that the pod service account should be constrained to target namespaces |
+| scriptPods.tolerations | list | `[]` | The tolerations to apply to script pods |
 
 ### Other Values
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1948](https://img.shields.io/badge/AppVersion-8.1.1948-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1974](https://img.shields.io/badge/AppVersion-8.1.1974-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -30,7 +30,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1948"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.1974"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,5 @@
 # kubernetes-agent
 
-
 ![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1948](https://img.shields.io/badge/AppVersion-8.1.1948-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,5 +1,6 @@
 # kubernetes-agent
 
+
 ![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1948](https://img.shields.io/badge/AppVersion-8.1.1948-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
@@ -58,8 +59,10 @@ A Helm chart for the Octopus Kubernetes Agent
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| persistence.nfs.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the NFS pod |
 | persistence.nfs.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/nfs-server","tag":"1.0.1"}` | The repository, pullPolicy & tag to use for the NFS server |
 | persistence.nfs.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the NFS pod & container |
+| persistence.nfs.tolerations | list | `[]` | The tolerations to apply to the NFS pod |
 | persistence.nfs.watchdog.enabled | bool | `true` | If enabled, the NFS watchdog will monitor NFS availability and restart Tentacle and Script Pods if the NFS server is unresponsive |
 | persistence.nfs.watchdog.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-nfs-watchdog","tag":"0.1.0"}` | The repository, pullPolicy & tag to use for the NFS watchdog |
 | persistence.nfs.watchdog.initial_backoff_seconds | string | `""` | The initial backoff time in seconds to retry failed NFS checks @default 0.5 |

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -50,19 +50,13 @@ spec:
       volumes:
         - name: octopus-volume
           emptyDir:
-            sizeLimit: {{ .Values.persistence.size}}
+            sizeLimit: {{ .Values.persistence.size }}
+      {{- with .Values.persistence.nfs.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/os
-                  operator: In
-                  values:
-                    - linux
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - arm64
-                    - amd64
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.persistence.nfs.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -102,10 +102,16 @@ spec:
             {{- end }}
             - name: "OCTOPUS__K8STENTACLE__PODRESOURCEJSON"
               value: {{ .Values.scriptPods.resources | toJson | quote }}
+            - name: "OCTOPUS__K8STENTACLE__PODAFFINITYJSON"
+              value: {{ .Values.scriptPods.affinity | toJson | quote }}
+            {{- with .Values.scriptPods.tolerations }}
+            - name: "OCTOPUS__K8STENTACLE__PODTOLERATIONSJSON"
+              value: {{ .| toJson | quote }}
+            {{- end }}
             {{- if .Values.agent.serverApiKey }}
             - name: "ServerApiKey"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
                   key: api-key
             {{- end }}
@@ -180,20 +186,6 @@ spec:
             - mountPath: /octopus
               name: tentacle-home
         {{- end}}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/os
-                  operator: In
-                  values:
-                    - linux
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - arm64
-                    - amd64
       volumes:
         - name: tentacle-home
           persistentVolumeClaim:
@@ -202,5 +194,12 @@ spec:
         - name: octopus-server-certificate-configmap
           configMap:
             name: "octopus-server-certificate"
-        {{- end }}
-
+        {{- end }}    
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end}}

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1948
+        app.kubernetes.io/version: 8.1.1974
         helm.sh/chart: kubernetes-agent-1.10.3
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1948
+        app.kubernetes.io/version: 8.1.1974
         helm.sh/chart: kubernetes-agent-1.10.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.1948
+            app.kubernetes.io/version: 8.1.1974
             helm.sh/chart: kubernetes-agent-1.10.3
         spec:
           affinity:
@@ -98,7 +98,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1948
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.1974
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -94,6 +94,8 @@ should match snapshot:
                   value: "true"
                 - name: OCTOPUS__K8STENTACLE__PODRESOURCEJSON
                   value: '{"requests":{"cpu":"25m","memory":"100Mi"}}'
+                - name: OCTOPUS__K8STENTACLE__PODAFFINITYJSON
+                  value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
               image: octopusdeploy/kubernetes-agent-tentacle:8.1.1948

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1948
+        app.kubernetes.io/version: 8.1.1974
         helm.sh/chart: kubernetes-agent-1.10.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.1948
+        app.kubernetes.io/version: 8.1.1974
         helm.sh/chart: kubernetes-agent-1.10.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -249,3 +249,38 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODRESOURCEJSON')].value
         value: '{"limits":{"cpu":"100m","memory":"1Gi"},"requests":{"cpu":"10m","memory":"50Mi"}}'
+
+- it: Sets script pod affinity json if script pod affinity is changed
+  set:
+    scriptPods:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - arm64
+                - amd64
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODAFFINITYJSON')].value
+        value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
+
+- it: Sets pod tolerations json if script pod tolerations defined
+  set:
+    scriptPods:
+      tolerations:
+      - key: "tol-1"
+        operator: "Equal"
+        value: "val-1"
+        effect: "NoSchedule"
+      - key: "tol-21"
+        operator: "Equal"
+        value: "val-2"
+        effect: "NoSchedule"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODTOLERATIONSJSON')].value
+        value: '[{"effect":"NoSchedule","key":"tol-1","operator":"Equal","value":"val-1"},{"effect":"NoSchedule","key":"tol-21","operator":"Equal","value":"val-2"}]'

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -175,3 +175,55 @@ tests:
           value:
             - name: secret-1
             - name: secret-2
+
+  - it: Changes affinity if changed
+    set:
+      agent:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                  - arm64
+                  - amd64
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity
+          value: 
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - arm64
+                    - amd64
+
+  - it: Sets pod tolerations tolerations defined
+    set:
+      agent:
+        tolerations:
+        - key: "tol-1"
+          operator: "Equal"
+          value: "val-1"
+          effect: "NoSchedule"
+        - key: "tol-21"
+          operator: "Equal"
+          value: "val-2"
+          effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+          - key: "tol-1"
+            operator: "Equal"
+            value: "val-1"
+            effect: "NoSchedule"
+          - key: "tol-21"
+            operator: "Equal"
+            value: "val-2"
+            effect: "NoSchedule"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -216,6 +216,27 @@ persistence:
       annotations: {}
       labels: {}
 
+    # -- The tolerations to apply to the NFS pod
+    # @section -- Persistence
+    tolerations: []
+
+    # -- The affinities to apply to the NFS pod
+    # @section -- Persistence
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - arm64
+                  - amd64
+
     watchdog:
       # -- If enabled, the NFS watchdog will monitor NFS availability and restart Tentacle and Script Pods if the NFS server is unresponsive
       # @section -- Persistence

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -112,6 +112,27 @@ agent:
       memory: "150Mi"
       cpu: "100m"
 
+  # -- The tolerations to apply to the agent pod
+  # @section -- Agent values
+  tolerations: []
+
+  # -- The affinities to apply to the agent pod
+  # @section -- Agent values
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+                - arm64
+                - amd64
+
   debug:
     # -- Disables automatic pod cleanup
     # @section -- Agent values
@@ -148,6 +169,27 @@ scriptPods:
     # @default -- `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]},{"nonResourceURLs":["*"],"verbs":["*"]}]`
     clusterRole:
       rules: []
+  
+  # -- The tolerations to apply to script pods
+  # @section -- Script pod values
+  tolerations: []
+
+  # -- The affinities to apply to script pods
+  # @section -- Script pod values
+  affinity: 
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+                - arm64
+                - amd64
 
 # @section -- Persistence
 persistence:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -88,7 +88,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.1948"
+    tag: "8.1.1974"
    
   serviceAccount:
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
Customers have asked us to allow them to set the pod affinity & tolerations on both the agent pod and script pods.

This PR adds these values to the `agent` section and `scriptPods` section

Shortcut story: [sc-86605]