### PR TITLE
Backport support for changing script pod image, tag and pullPolicy

### DIFF
--- a/.changeset/khaki-experts-hang.md
+++ b/.changeset/khaki-experts-hang.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Backport support for changing script pod image, tag and pullPolicy

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
 
 ## Maintainers
@@ -76,6 +76,7 @@ A Helm chart for the Octopus Kubernetes Agent
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
+| scriptPods.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image. If left blank, will use the `octopusdeploy/kubernetes-agent-tools-base` image. |
 | scriptPods.resources | object | `{"requests":{"cpu":"25m","memory":"100Mi"}}` | The resource limits and requests assigned to script pod containers |
 | scriptPods.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | scriptPods.serviceAccount.clusterRole | object | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]},{"nonResourceURLs":["*"],"verbs":["*"]}]` | if defined, overrides the default ClusterRole rules |

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -116,3 +116,21 @@ Turns the imagePullSecrets map into a CSV.
 {{- $imagePullSecretCsv }}
 {{- end }}
 {{- end }}
+
+{{/*
+The Env-var block required to set image name, tag and pullpolicy
+*/}}
+{{- define "kubernetes-agent.scriptPodEnvVars" -}}
+{{- if .repository }}
+- name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGE"
+  value: {{ .repository | quote}}
+{{- end }}
+{{- if .tag }}
+- name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGETAG"
+  value: {{ .tag | quote}}
+{{- end }}
+{{- if .pullPolicy }}
+- name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGEPULLPOLICY"
+  value: {{ .pullPolicy | quote}}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -64,6 +64,7 @@ spec:
               value: {{ join "," .Values.agent.targetTenantTags | quote }}
             - name: "TargetTenantedDeploymentParticipation"
               value: {{ .Values.agent.targetTenantedDeploymentParticipation | quote }}
+            {{- include "kubernetes-agent.scriptPodEnvVars" .Values.scriptPods.image | nindent 12 }}
             {{- with .Values.agent.machinePolicyName }}
             - name: "MachinePolicy"
               value: {{ . | quote }}

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -284,3 +284,28 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODTOLERATIONSJSON')].value
         value: '[{"effect":"NoSchedule","key":"tol-1","operator":"Equal","value":"val-1"},{"effect":"NoSchedule","key":"tol-21","operator":"Equal","value":"val-2"}]'
+
+- it: "Sets Image Pod from DeploymentTarget Values if defined"
+  set:
+    scriptPods.image:
+      repository: "deployment_target_image_repository"
+      tag: "1.0.0-deploymentTarget"
+      pullPolicy: "Always"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGE')].value
+        value: "deployment_target_image_repository"
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGETAG')].value
+        value: "1.0.0-deploymentTarget"
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGEPULLPOLICY')].value
+        value: "Always"
+        
+- it: "When running as a deployment Target, script pod image is not set by default"
+  set:
+    agent.deploymentTarget.enabled: true
+    agent.worker.enabled: false
+  asserts:
+    - notExists:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGE')].value

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -191,6 +191,13 @@ scriptPods:
                 - arm64
                 - amd64
 
+  # -- The repository, pullPolicy & tag to use for the script pod image. If left blank, will use the `octopusdeploy/kubernetes-agent-tools-base` image.
+  # @section -- Script pod values
+  image:
+    repository: ""
+    pullPolicy: ""
+    tag: ""
+
 # @section -- Persistence
 persistence:
   


### PR DESCRIPTION
V2 added support for changing the scriptPods image in #236.

This backports that change to v1. The current tentacle version already supports these tags