### PR TITLE
Fix GHA to automatically tag commit when versioning PR merged

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -30,8 +30,11 @@ jobs:
         version: 8.15.2
         run_install: true
 
-    - name: Publish Version Tag
-      run: pnpm publish-version-tags
+    - name: 'Tag version'
+      run: |
+        version=$(jq -r .version charts/kubernetes-agent/package.json)
+        git tag $version
+        git push origin refs/tags/$version
 
   version:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "description": "The official Octopus helm charts",
     "scripts": {
         "changeset": "changeset",
-        "ci:version": "run changeset version && install",
-        "publish-version-tags": "pnpm changeset publish && git push --follow-tags"
+        "ci:version": "run changeset version && install"
     },
     "devDependencies": {
         "@changesets/cli": "^2.27.1"


### PR DESCRIPTION
2 issues:

1. The changeset versioning tag is `xxx@version` where as we have been using `xxx/version`. This cannot be altered in changesets
2. The `git push --follow-tags` didn't work. I've been manually tagging the commits afterwards.

The change is now to just pull the version from the `package.json` and create and push that new tag