### PR TITLE
Exit pre-release versioning mode to release v2 of the Kubernetes Agent helm chart

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "kubernetes-agent": "1.7.0"


### PR DESCRIPTION
This [exits](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) the pre-release mode that is being used to develop v2-alpha.

The next automatic versioning PR will update the version to 2.0.0 and update the changelog.