### PR TITLE
Moving Kubernetes Agent readme content down to readme file in the chart folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,7 @@
 
 ![Octopus Deploy & Kubernetes](octopus-kubernetes.png)
 
-This repository contains the officially supported [Helm](https://helm.sh) chart for deploying [Octopus Deploy](https://octopus.com).
+This repository contains the [Helm](https://helm.sh) charts supported by [Octopus Deploy](https://octopus.com).
 
-- [Octopus Deploy](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/octopus-deploy) - Self-host the Octopus Deploy server.
-
-## Kubernetes agent
-
-The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using Octopus Deploy.
-
-The helm chart is hosted on [Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent), where you can pull it using Helm.
-
-The source code for the chart can be found at [here](./charts/kubernetes-agent).
-
-### Values documentation
-
-The [Readme.md](./charts/kubernetes-agent/readme.md) in the chart directory contains the documentation for the `values.yaml`.
-
-As the structure of the `values.yaml` may change between major versions, see below to find the correct `readme.md` for each version.
-
-### Versions
-
-The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
-
-- *major* - Breaking changes to the chart. This may include adding or removing of resources, breaking changes in the agent application image or breaking changes to the structure of the `values.yaml`.
-- *minor* - New non-breaking features. New features or improvements to the agent application or helm chart itself. 
-- *patch* - Minor non-breaking bug fixes or changes that do not introduce new features.
-
-The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
-
-
-| Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| 2 (alpha) | [main](./charts/kubernetes-agent)                                                                                                    | [here](./charts/kubernetes-agent/readme.md)                                                                             | [here](./charts/kubernetes-agent/values.yaml)                                                                             |
-| 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
+- [Octopus Deploy](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/octopus-deploy) - Self-host the Octopus Deploy server on your own Kubernetes cluster.
+- [Kubernetes Agent](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent) - The agent which allows Octopus to run workloads on your Kubernetes clusters. 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,4 +1,3 @@
-
 ## Kubernetes agent
 
 ![Version: 2.0.0-alpha.5](https://img.shields.io/badge/Version-2.0.0--alpha.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1985](https://img.shields.io/badge/AppVersion-8.1.1985-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
@@ -19,10 +18,12 @@ The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org
 
 The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
 
+
 | Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| 2 (alpha) | [main](./charts/kubernetes-agent)                                                                                                    | This file                                                                             | [here](./charts/kubernetes-agent/values.yaml)                                                                             |
+| 2 (alpha) | [main](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent)                                               | This file                                                                                                               | [here](./values.yaml)                                                                                                     |
 | 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
+
 
 ## Maintainers
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -8,7 +8,7 @@ The helm chart is hosted on [Docker Hub](https://hub.docker.com/r/octopusdeploy/
 
 The source code for the chart can be found at [here](./charts/kubernetes-agent).
 
-### Versions
+## Versions
 
 The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
 
@@ -18,12 +18,10 @@ The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org
 
 The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
 
-
 | Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | 2 (alpha) | [main](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent)                                               | This file                                                                                                               | [here](./values.yaml)                                                                                                     |
 | 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
-
 
 ## Maintainers
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,21 +1,34 @@
-# kubernetes-agent
+
+## Kubernetes agent
 
 ![Version: 2.0.0-alpha.5](https://img.shields.io/badge/Version-2.0.0--alpha.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.1985](https://img.shields.io/badge/AppVersion-8.1.1985-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
-A Helm chart for the Octopus Kubernetes Agent
+The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
-**Homepage:** <https://octopus.com> 
-**Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
+The helm chart is hosted on [Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent), where you can pull it using Helm.
+
+The source code for the chart can be found at [here](./charts/kubernetes-agent).
+
+### Versions
+
+The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
+
+- *major* - Breaking changes to the chart. This may include adding or removing of resources, breaking changes in the agent application image or breaking changes to the structure of the `values.yaml`.
+- *minor* - New non-breaking features. New features or improvements to the agent application or helm chart itself.
+- *patch* - Minor non-breaking bug fixes or changes that do not introduce new features.
+
+The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
+
+| Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 2 (alpha) | [main](./charts/kubernetes-agent)                                                                                                    | This file                                                                             | [here](./charts/kubernetes-agent/values.yaml)                                                                             |
+| 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
 
 ## Maintainers
 
 | Name | Email | Url |
 | ---- | ------ | --- |
 | Octopus Deploy | <support@octopus.com> | <https://octopus.com> |
-
-## Source Code
-
-* <https://github.com/OctopusDeploy/helm-charts>
 
 ## Values
 

--- a/charts/kubernetes-agent/README.md.gotmpl
+++ b/charts/kubernetes-agent/README.md.gotmpl
@@ -1,4 +1,3 @@
-
 ## Kubernetes agent
 
 {{ template "chart.badgesSection" . }}![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
@@ -14,7 +13,7 @@ The source code for the chart can be found at [here](./charts/kubernetes-agent).
 The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
 
 - *major* - Breaking changes to the chart. This may include adding or removing of resources, breaking changes in the agent application image or breaking changes to the structure of the `values.yaml`.
-- *minor* - New non-breaking features. New features or improvements to the agent application or helm chart itself. 
+- *minor* - New non-breaking features. New features or improvements to the agent application or helm chart itself.
 - *patch* - Minor non-breaking bug fixes or changes that do not introduce new features.
 
 The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
@@ -22,7 +21,7 @@ The `main` branch will reflect the current development version of the chart. Thi
 
 | Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| 2 (alpha) | [main](./charts/kubernetes-agent)                                                                                                    | This file                                                                             | [here](./values.yaml)                                                                             |
+| 2 (alpha) | [main](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent)                                               | This file                                                                                                               | [here](./values.yaml)                                                                                                     |
 | 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
 
 

--- a/charts/kubernetes-agent/README.md.gotmpl
+++ b/charts/kubernetes-agent/README.md.gotmpl
@@ -8,7 +8,7 @@ The helm chart is hosted on [Docker Hub](https://hub.docker.com/r/octopusdeploy/
 
 The source code for the chart can be found at [here](./charts/kubernetes-agent).
 
-### Versions
+## Versions
 
 The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
 
@@ -18,12 +18,10 @@ The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org
 
 The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
 
-
 | Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | 2 (alpha) | [main](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent)                                               | This file                                                                                                               | [here](./values.yaml)                                                                                                     |
 | 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
-
 
 {{ template "chart.maintainersSection" . }}
 

--- a/charts/kubernetes-agent/README.md.gotmpl
+++ b/charts/kubernetes-agent/README.md.gotmpl
@@ -1,15 +1,32 @@
-{{ template "chart.header" . }}
+
+## Kubernetes agent
 
 {{ template "chart.badgesSection" . }}![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
-{{ template "chart.description" . }}
+The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
-{{ template "chart.homepageLine" . }}  
-**Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent)
+The helm chart is hosted on [Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent), where you can pull it using Helm.
+
+The source code for the chart can be found at [here](./charts/kubernetes-agent).
+
+### Versions
+
+The Kubernetes agent Helm chart follows [Semantic Versioning](https://semver.org/). Generally, version updates can be interpreted as follows:
+
+- *major* - Breaking changes to the chart. This may include adding or removing of resources, breaking changes in the agent application image or breaking changes to the structure of the `values.yaml`.
+- *minor* - New non-breaking features. New features or improvements to the agent application or helm chart itself. 
+- *patch* - Minor non-breaking bug fixes or changes that do not introduce new features.
+
+The `main` branch will reflect the current development version of the chart. This may be the latest released version or if a new version is in development, may be a pre-release version.
+
+
+| Version   | Branch                                                                                                                               | Readme                                                                                                                  | values.yaml                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 2 (alpha) | [main](./charts/kubernetes-agent)                                                                                                    | This file                                                                             | [here](./values.yaml)                                                                             |
+| 1         | [release/kubernetes-agent/v1](https://github.com/OctopusDeploy/helm-charts/tree/release/kubernetes-agent/v1/charts/kubernetes-agent) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/README.md) | [here](https://github.com/OctopusDeploy/helm-charts/blob/release/kubernetes-agent/v1/charts/kubernetes-agent/values.yaml) |
+
 
 {{ template "chart.maintainersSection" . }}
-
-{{ template "chart.sourcesSection" . }}
 
 {{ template "chart.valuesSection" . }}
 


### PR DESCRIPTION
The content shown below has been moved from the main README.md to the [Kubernetes Agent chart README](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/README.md)

The driver for this is the main readme is shown on the package repositories linked to the repo, specifically the repository containing the [Octopus Server helm chart](https://github.com/OctopusDeploy/helm-charts/pkgs/container/octopusdeploy-helm).  This is currently confusing, as at first glance it appears the documentation is for the Agent helm chart, rather than the Server chart.



![image](https://github.com/user-attachments/assets/b3648ffe-5985-41c9-be82-5802f04cd685)

