### PR TITLE
Read from octopus-deploy chart YAML not kubernetes-agent

### DIFF
--- a/.changeset/stupid-donuts-warn.md
+++ b/.changeset/stupid-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": major
+---
+
+Release v1 of Octopus Deploy helm chart

--- a/.github/workflows/octopus-publish-chart.yml
+++ b/.github/workflows/octopus-publish-chart.yml
@@ -49,7 +49,7 @@ jobs:
         uses: pietrobolcato/action-read-yaml@1.1.0
         id: read_chart_yaml
         with:
-          config: ${{ github.workspace }}/charts/kubernetes-agent/Chart.yaml
+          config: ${{ github.workspace }}/charts/octopus-deploy/Chart.yaml
 
       - name: Get branch names
         id: branch_names


### PR DESCRIPTION
During the merge for #264, I realised that we read from the kubernetes-agent YAML, not octopus-deploy, so inadvertently released a v2.0.0 accidentally.