### PR TITLE
Forward merge from release/kubernetes-agent/v1

### DIFF
--- a/.changeset/stupid-bats-doubt.md
+++ b/.changeset/stupid-bats-doubt.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Forward merge from release/kubernetes-agent/v1. Includes changes added in `1.4.2`.

--- a/.changeset/stupid-bats-doubt.md
+++ b/.changeset/stupid-bats-doubt.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": patch
 ---
 
-Forward merge from release/kubernetes-agent/v1. Includes changes added in `1.4.2`.
+Forward merge from release/kubernetes-agent/v1. Includes changes added in `1.14.2`.

--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -60,6 +60,12 @@ Version 2 has breaking changes and upgrading from Version 1 requires manual migr
 
 - 05fa04c: Creating Kubernetes Agent v2 alpha prerelease
 
+## 1.14.2
+
+### Patch Changes
+
+- c8a7da3: Update kubernetes-agent-tentacle to 8.1.2049. Removes the `KubernetesScriptServiceV1Alpha` service
+
 ## 1.14.1
 
 ### Patch Changes

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "2.0.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.2007"
+appVersion: "8.1.2049"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2007](https://img.shields.io/badge/AppVersion-8.1.2007-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2049](https://img.shields.io/badge/AppVersion-8.1.2049-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -49,7 +49,7 @@ This is documented [here](./migrations.md).
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.2007"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.2049"}` | The repository, pullPolicy & tag to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2007
+        app.kubernetes.io/version: 8.1.2049
         helm.sh/chart: kubernetes-agent-2.0.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2007
+        app.kubernetes.io/version: 8.1.2049
         helm.sh/chart: kubernetes-agent-2.0.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.2007
+            app.kubernetes.io/version: 8.1.2049
             helm.sh/chart: kubernetes-agent-2.0.0
         spec:
           affinity:
@@ -102,7 +102,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.2007
+              image: octopusdeploy/kubernetes-agent-tentacle:8.1.2049
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2007
+        app.kubernetes.io/version: 8.1.2049
         helm.sh/chart: kubernetes-agent-2.0.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2007
+        app.kubernetes.io/version: 8.1.2049
         helm.sh/chart: kubernetes-agent-2.0.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -117,7 +117,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.2007"
+    tag: "8.1.2049"
    
   serviceAccount:
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
Includes changes from `1.4.2`
- Update kubernetes-agent-tentacle to 8.1.2049 (#281)