### PR TITLE
Fix permissions when running as worker

### DIFF
--- a/.changeset/curly-ties-exist.md
+++ b/.changeset/curly-ties-exist.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Limit worker influence to local namespace

--- a/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
@@ -1,4 +1,4 @@
-{{- if empty .Values.scriptPods.serviceAccount.targetNamespaces }}
+{{- if  and (empty .Values.scriptPods.serviceAccount.targetNamespaces) (not .Values.agent.worker.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
@@ -4,6 +4,7 @@ templates:
 tests:
 - it: "is not created when target namespaces is not empty"
   set:
+    agent.worker.enabled: false
     scriptPods:
       serviceAccount:
         targetNamespaces: ["ns-1"]
@@ -14,3 +15,10 @@ tests:
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}
+    
+- it: "worker should not attach cluster role binding to serviceAccount"
+  set:
+    agent.worker.enabled: true
+  asserts:
+    - hasDocuments:
+        count: 0

--- a/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
@@ -4,7 +4,6 @@ templates:
 tests:
 - it: "is not created when target namespaces is not empty"
   set:
-    agent.worker.enabled: false
     scriptPods:
       serviceAccount:
         targetNamespaces: ["ns-1"]


### PR DESCRIPTION
It was found that when running as a worker, the clusterrole (used in deployment-target mode) was still attached to the service account being used to run scritps.

This meant that worker-scripts were able affect the greater cluster.

This fix removes the cluster-rolebinding from the serviceAccount when in worker-mode.

<img width="3124" alt="image" src="https://github.com/user-attachments/assets/b4104c9c-414d-472d-917a-9f3695a1f609">
