### PR TITLE
Create Clusterrole allowing pv actions

### DIFF
--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -72,6 +72,12 @@ Create the name of the pod cluster role for deleting pods
 {{- printf "%s-delete-role" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
 {{- end }}
 
+{{/*
+Create the name of the pod cluster role for creating a persistent volume
+*/}}
+{{- define "kubernetes-agent.scriptPodPvMakerClusterRoleName" -}}
+{{- printf "%s-pv-maker-role" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
+{{- end }}
 
 {{/*
 Create the name of the pod (namespaced) role for creating pods, and updating tentacle
@@ -85,6 +91,13 @@ Create the name of the pod (namespaced) role for creating pods, and updating ten
 Create the name of the pod cluster role binding to use
 */}}
 {{- define "kubernetes-agent.scriptPodClusterRoleBindingName" -}}
+{{- printf "%s-binding" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
+Create the name of the pod cluster role binding to allow for PV modification
+*/}}
+{{- define "kubernetes-agent.scriptPodPvMakerClusterRoleBindingName" -}}
 {{- printf "%s-binding" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
 {{- end }}
 

--- a/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
@@ -11,17 +11,17 @@ roleRef:
   kind: ClusterRole
   name: {{ include "kubernetes-agent.scriptPodClusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
-{{ else }}
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  pv_creator_to_serviceRole
+  name:  {{ include "kubernetes-agent.scriptPodPvMakerClusterRoleBindingName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubernetes-agent.scriptPodServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: pv_creator
+  name: {{ include "kubernetes-agent.scriptPodPvMakerClusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
@@ -11,4 +11,17 @@ roleRef:
   kind: ClusterRole
   name: {{ include "kubernetes-agent.scriptPodClusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
+{{ else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  pv_creator_to_serviceRole
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubernetes-agent.scriptPodServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: pv_creator
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/kubernetes-agent/templates/pod-clusterroles.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterroles.yaml
@@ -37,13 +37,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pv_maker
+  name: {{ include "kubernetes-agent.scriptPodPvMakerClusterRoleName" . }}
 rules:
   - apiGroups:
       - '*'
     resources:
-      - 'persistentvolumes'
+    - persistentvolumes
+    - persistentvolumeclaims
+    - persistentvolumeclaims/status
     verbs:
-      - 'create'
-      - 'list'
+    - create
+    - delete
+    - get
+    - list
+    - watch
+    - update
       

--- a/charts/kubernetes-agent/templates/pod-clusterroles.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterroles.yaml
@@ -32,3 +32,18 @@ rules:
       - 'delete'
       - 'list'
 {{- end }}
+---
+# this is required such that during upgrade we can query for PVs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pv_maker
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - 'persistentvolumes'
+    verbs:
+      - 'create'
+      - 'list'
+      

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-clusterbinding_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-clusterbinding_test.yaml.snap
@@ -12,3 +12,16 @@ should match snapshot:
       - kind: ServiceAccount
         name: octopus-agent-scripts
         namespace: NAMESPACE
+  2: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: octopus-agent-scripts-RELEASE-NAME-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: octopus-agent-scripts-RELEASE-NAME-pv-maker-role
+    subjects:
+      - kind: ServiceAccount
+        name: octopus-agent-scripts
+        namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-clusteroles_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-clusteroles_test.yaml.snap
@@ -28,3 +28,22 @@ should match snapshot:
         verbs:
           - delete
           - list
+  3: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: octopus-agent-scripts-RELEASE-NAME-pv-maker-role
+    rules:
+      - apiGroups:
+          - '*'
+        resources:
+          - persistentvolumes
+          - persistentvolumeclaims
+          - persistentvolumeclaims/status
+        verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+          - update


### PR DESCRIPTION
This clusterrole is then applied to the service-account via a cluster-role binding such that worker script-pods may operate on persistent-volumes, as is required during a helm upgrade.