### PR TITLE
Add service account for upgrading

### DIFF
--- a/.changeset/brown-ways-accept.md
+++ b/.changeset/brown-ways-accept.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add service account used by Octopus Server to perform automatic upgrades

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -59,14 +59,14 @@ Used for the pod cluster role & clusterrole binding as they are not namespaced.
 {{- end }}
 
 {{/*
-Create the name of the service account to use for the auto upgrader
+Create the name of the service account used by Octopus Server to perform automatic upgrades
 */}}
 {{- define "kubernetes-agent.autoUpgraderServiceAccountName" -}}
 {{- print "octopus-agent-auto-upgrader" }}
 {{- end }}
 
 {{/*
-Used for the auto upgrader cluster role & clusterrole binding as they are not namespaced
+Used for the auto upgrader service account cluster role & clusterrole binding as they are not namespaced
 */}}
 {{- define "kubernetes-agent.autoUpgraderServiceAccountFullName" -}}
 {{- printf "%s-%s" ( include "kubernetes-agent.autoUpgraderServiceAccountName" .) .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -38,14 +38,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for Tentacle
 */}}
 {{- define "kubernetes-agent.serviceAccountName" -}}
 {{- .Values.agent.serviceAccount.name | default (printf "%s-tentacle" (include "kubernetes-agent.name" .)) }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the service account to use for script pods
 */}}
 {{- define "kubernetes-agent.scriptPodServiceAccountName" -}}
 {{- .Values.scriptPods.serviceAccount.name | default (printf "%s-scripts" (include "kubernetes-agent.name" .)) }}
@@ -56,6 +56,20 @@ Used for the pod cluster role & clusterrole binding as they are not namespaced.
 */}}
 {{- define "kubernetes-agent.scriptPodServiceAccountFullName" -}}
 {{- printf "%s-%s" ( include "kubernetes-agent.scriptPodServiceAccountName" .) .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the auto upgrader
+*/}}
+{{- define "kubernetes-agent.autoUpgraderServiceAccountName" -}}
+{{- print "octopus-agent-auto-upgrader" }}
+{{- end }}
+
+{{/*
+Used for the auto upgrader cluster role & clusterrole binding as they are not namespaced
+*/}}
+{{- define "kubernetes-agent.autoUpgraderServiceAccountFullName" -}}
+{{- printf "%s-%s" ( include "kubernetes-agent.autoUpgraderServiceAccountName" .) .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -70,6 +84,20 @@ Create the name of the pod cluster role for deleting pods
 */}}
 {{- define "kubernetes-agent.scriptPodDeleterClusterRoleName" -}}
 {{- printf "%s-delete-role" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role for performing auto upgrades
+*/}}
+{{- define "kubernetes-agent.autoUpgraderClusterRoleName" -}}
+{{- printf "%s-role" (include "kubernetes-agent.autoUpgraderServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
+Create the name of the auto upgrader cluster role binding to use
+*/}}
+{{- define "kubernetes-agent.autoUpgraderClusterRoleBindingName" -}}
+{{- printf "%s-binding" (include "kubernetes-agent.autoUpgraderServiceAccountFullName" .) }}
 {{- end }}
 
 {{/*

--- a/charts/kubernetes-agent/templates/auto-upgrader-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-clusterbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ include "kubernetes-agent.autoUpgraderClusterRoleBindingName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubernetes-agent.autoUpgraderServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kubernetes-agent.autoUpgraderClusterRoleName" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kubernetes-agent/templates/auto-upgrader-clusterrole.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubernetes-agent.autoUpgraderClusterRoleName" . }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]

--- a/charts/kubernetes-agent/templates/auto-upgrader-serviceaccount.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubernetes-agent.autoUpgraderServiceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "kubernetes-agent.labels" . | nindent 4 }}
+automountServiceAccountToken: true

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-clusterbinding_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-clusterbinding_test.yaml.snap
@@ -1,0 +1,14 @@
+should match snapshot:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: octopus-agent-auto-upgrader-RELEASE-NAME-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: octopus-agent-auto-upgrader-RELEASE-NAME-role
+    subjects:
+      - kind: ServiceAccount
+        name: octopus-agent-auto-upgrader
+        namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-clusterrole_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-clusterrole_test.yaml.snap
@@ -1,0 +1,13 @@
+should match snapshot:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: octopus-agent-auto-upgrader-RELEASE-NAME-role
+    rules:
+      - apiGroups:
+          - '*'
+        resources:
+          - '*'
+        verbs:
+          - '*'

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -1,0 +1,14 @@
+should match snapshot:
+  1: |
+    apiVersion: v1
+    automountServiceAccountToken: true
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: octopus-agent
+        app.kubernetes.io/version: 8.1.2099
+        helm.sh/chart: kubernetes-agent-1.15.0
+      name: octopus-agent-auto-upgrader
+      namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/auto-upgrader-clusterbinding_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-clusterbinding_test.yaml
@@ -1,0 +1,7 @@
+suite: "pod permissions"
+templates:
+- templates/auto-upgrader-clusterbinding.yaml
+tests:
+- it: "should match snapshot"
+  asserts:
+  - matchSnapshot: {}

--- a/charts/kubernetes-agent/tests/auto-upgrader-clusterrole_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-clusterrole_test.yaml
@@ -1,0 +1,7 @@
+suite: "pod permissions"
+templates:
+- templates/auto-upgrader-clusterrole.yaml
+tests:
+- it: "should match snapshot"
+  asserts:
+  - matchSnapshot: {}

--- a/charts/kubernetes-agent/tests/auto-upgrader-serviceaccount_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-serviceaccount_test.yaml
@@ -1,0 +1,18 @@
+suite: "pod permissions"
+templates:
+- templates/auto-upgrader-serviceaccount.yaml
+tests:
+- it: "should match snapshot"
+  asserts:
+  - matchSnapshot: {}
+
+- it: "should have fixed service account name"
+  set: 
+    agent:
+      targetName: "test"
+    nameOverride: "test_test"
+  asserts:
+  - equal:
+      path: "metadata.name"
+      value: "octopus-agent-auto-upgrader"
+    


### PR DESCRIPTION
We have identified an issue where the permissions for the scripts pods do not allow for Octopus Server to perform automatic upgrading.

To resolve this, we are adding a new service account with cluster-wide permissions that is only used by Octopus Server to perform automatic upgrades.

This is part of the fix for: https://github.com/OctopusDeploy/Issues/issues/8985