### PR TITLE
Update NFS Watchdog to 0.2.0

### DIFF
--- a/.changeset/witty-wolves-live.md
+++ b/.changeset/witty-wolves-live.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Bump kubernetes-agent-nfs-watchdog default tag to 0.2.0

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -69,7 +69,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | persistence.nfs.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the NFS pod & container |
 | persistence.nfs.tolerations | list | `[]` | The tolerations to apply to the NFS pod |
 | persistence.nfs.watchdog.enabled | bool | `true` | If enabled, the NFS watchdog will monitor NFS availability and restart Tentacle and Script Pods if the NFS server is unresponsive |
-| persistence.nfs.watchdog.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-nfs-watchdog","tag":"0.1.0"}` | The repository, pullPolicy & tag to use for the NFS watchdog |
+| persistence.nfs.watchdog.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-nfs-watchdog","tag":"0.2.0"}` | The repository, pullPolicy & tag to use for the NFS watchdog |
 | persistence.nfs.watchdog.initial_backoff_seconds | string | `""` | The initial backoff time in seconds to retry failed NFS checks @default 0.5 |
 | persistence.nfs.watchdog.loop_seconds | string | `""` | The frequency in seconds to check the NFS server @default 5 |
 | persistence.nfs.watchdog.timeout_seconds | string | `""` | The total time to retry failed NFS checks before giving up and deleting the pod @default 10 |

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -83,7 +83,7 @@ should match snapshot:
                 - name: OCTOPUS__K8STENTACLE__DISABLEPODEVENTSINTASKLOG
                   value: "false"
                 - name: OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE
-                  value: octopusdeploy/kubernetes-agent-nfs-watchdog:0.1.0
+                  value: octopusdeploy/kubernetes-agent-nfs-watchdog:0.2.0
                 - name: OCTOPUS__TENTACLE__LOGLEVEL
                   value: Info
                 - name: TentacleHome
@@ -121,7 +121,7 @@ should match snapshot:
             - env:
                 - name: watchdog_directory
                   value: /octopus
-              image: octopusdeploy/kubernetes-agent-nfs-watchdog:0.1.0
+              image: octopusdeploy/kubernetes-agent-nfs-watchdog:0.2.0
               imagePullPolicy: IfNotPresent
               name: nfs-watchdog
               volumeMounts:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -293,7 +293,7 @@ persistence:
       image:
         repository: octopusdeploy/kubernetes-agent-nfs-watchdog
         pullPolicy: IfNotPresent
-        tag: "0.1.0"
+        tag: "0.2.0"
 
 # Used for integration testing to avoid registering with a real Octopus Server
 # @ignored


### PR DESCRIPTION
Bumps the NFS Watchdog to `0.2.0`.

Includes the following change:

https://github.com/OctopusDeploy/kubernetes-agent-nfs-watchdog/pull/1