### PR TITLE
Forward merge from release/kubernetes-agent/v1

### DIFF
--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -91,6 +91,18 @@ Version 2 has breaking changes and upgrading from Version 1 requires manual migr
 
 - 05fa04c: Creating Kubernetes Agent v2 alpha prerelease
 
+## 1.17.0
+
+### Minor Changes
+
+- eb21cd0: Updated the Kubernetes Tentacle to version 8.2.2165, featuring an upgrade from .NET 6 to .NET 8
+
+  - This release now uses a Debian 12 base image and features a libssl update from v1 to v3
+
+  Introduced support for an optional tag suffix in the agent image tag configuration within the Helm chart
+
+  - This allows for choosing an alternative base distribution for the Kubernetes Tentacle image based on available options
+
 ## 1.16.1
 
 ### Patch Changes

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "2.2.1"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.1.2099"
+appVersion: "8.2.2165"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.2099](https://img.shields.io/badge/AppVersion-8.1.2099-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.2165](https://img.shields.io/badge/AppVersion-8.2.2165-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -49,7 +49,7 @@ This is documented [here](./migrations.md).
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.1.2099"}` | The repository, pullPolicy & tag to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.2.2165","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -171,3 +171,22 @@ The Env-var block required to set image name, tag and pullpolicy
   value: {{ .pullPolicy | quote}}
 {{- end }}
 {{- end }}
+
+{{/*
+The base image for the agent, without any suffixes.
+Defaults to the Chart Appversion.
+*/}}
+{{- define "kubernetes-agent.image" -}}
+{{- printf "%s:%s" .Values.agent.image.repository (.Values.agent.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+The complete image for the agent, including any optional suffixes.
+*/}}
+{{- define "kubernetes-agent.fullImage" -}}
+{{- if .Values.agent.image.tagSuffix }}
+{{- printf "%s-%s" (include "kubernetes-agent.image" .) .Values.agent.image.tagSuffix }}
+{{- else }}
+{{- (include "kubernetes-agent.image" .) }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{printf "%s-tentacle" (include "kubernetes-agent.name" .) }}
-          image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "kubernetes-agent.fullImage" . | quote }}
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           startupProbe:
             exec:

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2099
+        app.kubernetes.io/version: 8.2.2165
         helm.sh/chart: kubernetes-agent-2.2.1
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2099
+        app.kubernetes.io/version: 8.2.2165
         helm.sh/chart: kubernetes-agent-2.2.1
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2099
+        app.kubernetes.io/version: 8.2.2165
         helm.sh/chart: kubernetes-agent-2.2.1
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.1.2099
+            app.kubernetes.io/version: 8.2.2165
             helm.sh/chart: kubernetes-agent-2.2.1
         spec:
           affinity:
@@ -104,7 +104,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.1.2099
+              image: octopusdeploy/kubernetes-agent-tentacle:8.2.2165
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2099
+        app.kubernetes.io/version: 8.2.2165
         helm.sh/chart: kubernetes-agent-2.2.1
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.1.2099
+        app.kubernetes.io/version: 8.2.2165
         helm.sh/chart: kubernetes-agent-2.2.1
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -176,7 +176,7 @@ tests:
             - name: secret-1
             - name: secret-2
 
-  - it: Changes affinity if changed
+  - it: "Changes affinity if changed"
     set:
       agent:
         affinity:
@@ -203,7 +203,7 @@ tests:
                     - arm64
                     - amd64
 
-  - it: Sets pod tolerations if defined
+  - it: "Sets pod tolerations if defined"
     set:
       agent:
         tolerations:
@@ -228,7 +228,7 @@ tests:
             value: "val-2"
             effect: "NoSchedule"
 
-  - it: Sets pod security context if defined
+  - it: "Sets pod security context if defined"
     set:
       agent:
         securityContext:
@@ -242,3 +242,28 @@ tests:
             runAsUser: 10101
             runAsGroup: 234
             fsGroup: 545
+  
+  - it: "includes the tag suffix in the agent image tag when defined"
+    set:
+      agent:
+        image:
+          repository: "myImageRepository"
+          pullPolicy: IfNotPresent
+          tag: "1.2.3"
+          tagSuffix: "bullseye-slim"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "myImageRepository:1.2.3-bullseye-slim"
+          
+  - it: "uses default agent image with suffix when tag is undefined"
+    set:
+      agent:
+        image:
+          pullPolicy: IfNotPresent
+          tag: ""
+          tagSuffix: "bullseye-slim"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.2.2165-bullseye-slim"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -112,12 +112,13 @@ agent:
     username: ""
     password: ""
 
-  # -- The repository, pullPolicy & tag to use for the agent image
+  # -- The repository, pullPolicy, tag & tagSuffix to use for the agent image
   # @section -- Agent values
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.1.2099"
+    tag: "8.2.2165"
+    tagSuffix: ""
    
   serviceAccount:
     # -- The name of the service account for the agent pod


### PR DESCRIPTION
Upgrades Kubernetes Tentacle to .NET 8 & Debian 12 as per #310 