### PR TITLE
feat: add topology spread constraints to OD StatefulSet

### DIFF
--- a/.changeset/grumpy-dots-yell.md
+++ b/.changeset/grumpy-dots-yell.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Add topology spread constraints

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -35,6 +35,10 @@ spec:
       nodeSelector:
       {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.octopus.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}

--- a/charts/octopus-deploy/tests/od_statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/od_statefulset_test.yaml
@@ -115,3 +115,19 @@ tests:
             values:
               - "val1"
         documentIndex: 0
+
+  - it: podTopologyConstraints is correctly set
+    set:
+      octopus:
+        topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: octopus-server
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels
+          value:
+            app.kubernetes.io/component: octopus-server

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -125,6 +125,7 @@ octopus:
   #    cpu: "1"
 
   tolerations: [] 
+  topologySpreadConstraints: []
 
   serviceAccount:
     create: false


### PR DESCRIPTION
This PR adds topology spread constraints, as well as a test for them. This should allow people to spread their server installations over multiple domains much easier. 
An example of how you could use this is as follows:
```
octopus:
  topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: zone
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        app.kubernetes.io/component: octopus-server
```
This would ensure that pods need to be spread evenly (with a maximum skew of 1) over the `zone` topology key. 