### PR TITLE
Change NFS CSI driver version to v4.*.*

### DIFF
--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesClusterInstaller.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/KubernetesClusterInstaller.cs
@@ -106,7 +106,7 @@ public class KubernetesClusterInstaller : IDisposable
             "--atomic",
             "--repo https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts",
             "--namespace kube-system",
-            "--version v4.6.0",
+            "--version \"v4.*.*\"",
             $"--kubeconfig \"{KubeConfigPath}\"",
             "csi-driver-nfs",
             "csi-driver-nfs"


### PR DESCRIPTION
We are changing the default version string in Server to `v4.*.*` so we get the latest version in the `v4` major version range.

This just updates this to be the same

Shortcut story: [sc-94493]