### PR TITLE
Fix a quoting issue with pollingProxy.port

### DIFF
--- a/.changeset/khaki-carrots-collect.md
+++ b/.changeset/khaki-carrots-collect.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Fix a quoting issue with agent.pollingProxy.port

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -164,7 +164,7 @@ spec:
             - name: "TentaclePollingProxyHost"
               value: {{ .Values.agent.pollingProxy.host | quote }}
             - name: "TentaclePollingProxyPort"
-              value: {{ .Values.agent.pollingProxy.port }}
+              value: {{ .Values.agent.pollingProxy.port | quote }}
             - name: "TentaclePollingProxyUsername"
               value: {{ .Values.agent.pollingProxy.username | quote }}              
             {{- if .Values.agent.pollingProxy.password }}

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -242,7 +242,7 @@ tests:
     agent:
       pollingProxy:
         host: "example.com"
-        port: 1234
+        port: "1234"
         username: "user"
         password: "pw-1234"
   asserts:
@@ -251,7 +251,7 @@ tests:
       value: "example.com"
   - equal:
       path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyPort')].value
-      value: 1234
+      value: "1234"
   - equal:
       path: spec.template.spec.containers[0].env[?(@.name == 'TentaclePollingProxyUsername')].value
       value: "user"

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -242,7 +242,7 @@ tests:
     agent:
       pollingProxy:
         host: "example.com"
-        port: "1234"
+        port: 1234
         username: "user"
         password: "pw-1234"
   asserts:


### PR DESCRIPTION
We've had a report from a customer that the missing quoting on the `agent.pollingProxy.port` was causing it to not work.

It's used as a string in the container script, so it's not an issue if it's quoted

