### PR TITLE
Update kubernetes-agent-tentacle to enable pod log encryption

### DIFF
--- a/.changeset/heavy-toes-jam.md
+++ b/.changeset/heavy-toes-jam.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Script pod logs are now encrypted to avoid leaking sensitive values

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.18.2"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.2.2481"
+appVersion: "8.2.2500"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.18.2"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.2.2500"
+appVersion: "8.2.2504"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.18.2](https://img.shields.io/badge/Version-1.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.2481](https://img.shields.io/badge/AppVersion-8.2.2481-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.18.2](https://img.shields.io/badge/Version-1.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.2500](https://img.shields.io/badge/AppVersion-8.2.2500-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -31,7 +31,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.2.2481","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.2.2500","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 # kubernetes-agent
 
-![Version: 1.18.2](https://img.shields.io/badge/Version-1.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.2500](https://img.shields.io/badge/AppVersion-8.2.2500-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 1.18.2](https://img.shields.io/badge/Version-1.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.2504](https://img.shields.io/badge/AppVersion-8.2.2504-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
@@ -31,7 +31,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.2.2500","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.2.2504","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2500
+        app.kubernetes.io/version: 8.2.2504
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2481
+        app.kubernetes.io/version: 8.2.2500
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2481
+        app.kubernetes.io/version: 8.2.2500
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2500
+        app.kubernetes.io/version: 8.2.2504
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2481
+        app.kubernetes.io/version: 8.2.2500
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.2.2481
+            app.kubernetes.io/version: 8.2.2500
             helm.sh/chart: kubernetes-agent-1.18.2
         spec:
           affinity:
@@ -100,7 +100,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.2.2481
+              image: octopusdeploy/kubernetes-agent-tentacle:8.2.2500
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2500
+        app.kubernetes.io/version: 8.2.2504
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.2.2500
+            app.kubernetes.io/version: 8.2.2504
             helm.sh/chart: kubernetes-agent-1.18.2
         spec:
           affinity:
@@ -100,7 +100,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.2.2500
+              image: octopusdeploy/kubernetes-agent-tentacle:8.2.2504
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2500
+        app.kubernetes.io/version: 8.2.2504
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2481
+        app.kubernetes.io/version: 8.2.2500
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2481
+        app.kubernetes.io/version: 8.2.2500
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.2.2500
+        app.kubernetes.io/version: 8.2.2504
         helm.sh/chart: kubernetes-agent-1.18.2
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -266,4 +266,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "octopusdeploy/kubernetes-agent-tentacle:8.2.2500-bullseye-slim"
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.2.2504-bullseye-slim"

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -266,4 +266,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "octopusdeploy/kubernetes-agent-tentacle:8.2.2481-bullseye-slim"
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.2.2500-bullseye-slim"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -103,7 +103,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.2.2500"
+    tag: "8.2.2504"
     tagSuffix: ""
   
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures. 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -103,7 +103,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.2.2481"
+    tag: "8.2.2500"
     tagSuffix: ""
   
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures. 

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/HelmChartBuilder.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/HelmChartBuilder.cs
@@ -17,7 +17,7 @@ namespace KubernetesAgent.Integration
             }
 
             var output = packager.StandardOutput.ReadToEnd();
-            return output.Split(":")[^1].ToString().Trim();
+            return output.Split(":", 2)[^1].ToString().Trim();
         }
 
         static string[] GetHelmChartPackageArguments(string version)

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/RunsAgentUpgrade.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/RunsAgentUpgrade.cs
@@ -64,7 +64,13 @@ public class HelmUpgradeTests(ITestOutputHelper output) : IAsyncLifetime
             .WithScriptFile(new ScriptFile(packageName, DataStream.FromBytes(packageBytes)))
             .Build();
 
-        void onScriptStatusResponseReceived(ScriptExecutionStatus res) => logger.Information("{Output}", string.Join(Environment.NewLine, res.Logs));
+        void onScriptStatusResponseReceived(ScriptExecutionStatus res)
+        {
+            foreach (var log in res.Logs)
+            {
+                logger.Information("[Script] {Date} | {Source} | {Text}", log.Occurred, log.Source, log.Text);
+            }
+        }
         async Task onScriptCompleted(CancellationToken t)
         {
             await Task.CompletedTask; 

--- a/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/Common/FileSystemInfoExtensionMethods.cs
+++ b/tests/kubernetes-agent/KubernetesAgent.IntegrationTests/Setup/Common/FileSystemInfoExtensionMethods.cs
@@ -4,11 +4,15 @@ public static class FileSystemInfoExtensionMethods
 {
     public static void MakeExecutable(this FileSystemInfo fsObject)
     {
-        var result = ProcessRunner.Run("chmod", "-R", "+x", fsObject.FullName);
-        if (result.ExitCode != 0)
+        if (!OperatingSystem.IsWindows())
         {
-            throw new Exception($"Failed to make {fsObject.FullName} executable. Exit code: {result.ExitCode}. stdout: {result.StandardOutput.ReadToEnd()}, stderr: {result.StandardError.ReadToEnd()}.");
+            var result = ProcessRunner.Run("chmod", "-R", "+x", fsObject.FullName);
+            if (result.ExitCode != 0)
+            {
+                throw new Exception($"Failed to make {fsObject.FullName} executable. Exit code: {result.ExitCode}. stdout: {result.StandardOutput.ReadToEnd()}, stderr: {result.StandardError.ReadToEnd()}.");
+            }
+
+            result.Close();
         }
-        result.Close();
     }
 }


### PR DESCRIPTION
Updates the tentacle container to include the changes https://github.com/OctopusDeploy/OctopusTentacle/pull/1047 and https://github.com/OctopusDeploy/OctopusTentacle/pull/1048 

As a result, all script pod logs will now be encrypted with a per-pod encryption key to avoid leaking sensitive values

Shortcut story: [sc-98480]