### PR TITLE
Update octopus-publish-chart.yml

### DIFF
--- a/.github/workflows/octopus-publish-chart.yml
+++ b/.github/workflows/octopus-publish-chart.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Package Chart
         run: helm package --version '${{ steps.version.outputs.CHART_VERSION }}' 'charts/octopus-deploy'
         
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload packaged chart
         with:
           name: '${{ steps.version.outputs.PACKAGE_NAME }}'


### PR DESCRIPTION
`upload-artifact@v3` is being [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)