### PR TITLE
Fix script pod image pull policy env var

### DIFF
--- a/.changeset/violet-paws-ring.md
+++ b/.changeset/violet-paws-ring.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Fix scriptPods.image.pullPolicy not working

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -151,15 +151,15 @@ The Env-var block required to set image name, tag and pullpolicy
 {{- define "kubernetes-agent.scriptPodEnvVars" -}}
 {{- if .repository }}
 - name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGE"
-  value: {{ .repository | quote}}
+  value: {{ .repository | quote }}
 {{- end }}
 {{- if .tag }}
 - name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGETAG"
-  value: {{ .tag | quote}}
+  value: {{ .tag | quote }}
 {{- end }}
 {{- if .pullPolicy }}
-- name: "OCTOPUS__K8STENTACLE__SCRIPTPODIMAGEPULLPOLICY"
-  value: {{ .pullPolicy | quote}}
+- name: "OCTOPUS__K8STENTACLE__SCRIPTPODPULLPOLICY"
+  value: {{ .pullPolicy | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - name: "OCTOPUS__K8STENTACLE__PODSERVICEACCOUNTNAME"
               value: {{ include "kubernetes-agent.scriptPodServiceAccountName" . | quote }}
             - name: "OCTOPUS__K8STENTACLE__PODVOLUMECLAIMNAME"
-              value: {{ (include "kubernetes-agent.pvcName" .)  | quote}}
+              value: {{ (include "kubernetes-agent.pvcName" .)  | quote }}
             - name: "OCTOPUS__K8STENTACLE__HELMRELEASENAME"
               value: {{ .Release.Name | quote}}
             - name: "OCTOPUS__K8STENTACLE__HELMCHARTVERSION"

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -374,7 +374,7 @@ tests:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGETAG')].value
         value: "1.0.0-deploymentTarget"
     - equal:
-        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGEPULLPOLICY')].value
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODPULLPOLICY')].value
         value: "Always"
         
 - it: "When running as a deployment Target, script pod image is not set by default"


### PR DESCRIPTION
The environment variable in Tentacle was named `SCRIPTPODPULLPOLICY` not `SCRIPTPODIMAGEPULLPOLICY`.

https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs#L44