### PR TITLE
Update download-artifact and upload-artifact to v4

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Package Chart
       run: helm package './charts/kubernetes-agent' --version '${{ steps.version.outputs.CHART_VERSION }}'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload packaged chart
       with:
         name: '${{ steps.version.outputs.PACKAGE_NAME }}'
@@ -121,7 +121,7 @@ jobs:
       id-token: write # This is required to obtain an ID token from GitHub Actions for the job
     steps:
     - name: Download packaged chart
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: '${{ needs.version_and_package.outputs.PACKAGE_NAME }}'
 


### PR DESCRIPTION
`upload-artifact@v3` and `download-artifact@v3`  are being [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)