### PR TITLE
Don't include empty worker pools env var if not a worker

### DIFF
--- a/.changeset/strong-pears-end.md
+++ b/.changeset/strong-pears-end.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Don't include an empty WorkerPools env var if not a worker

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -72,8 +72,10 @@ spec:
               value: {{ .Values.agent.deploymentTarget.initial.tenantedDeploymentParticipation | quote }}
             - name: "WorkerEnabled"
               value: {{ .Values.agent.worker.enabled | quote }}
+            {{- if and .Values.agent.worker.initial.workerPools .Values.agent.worker.enabled }}
             - name: "WorkerPools"
               value: {{ join "," .Values.agent.worker.initial.workerPools | quote }}
+            {{- end }}
             {{- if .Values.agent.deploymentTarget.enabled }}
             {{include "kubernetes-agent.scriptPodEnvVars" .Values.scriptPods.deploymentTarget.image | nindent 12}}
             {{- else if .Values.agent.worker.enabled }}

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -70,8 +70,6 @@ should match snapshot:
                   value: Untenanted
                 - name: WorkerEnabled
                   value: "false"
-                - name: WorkerPools
-                  value: ""
                 - name: OCTOPUS__K8STENTACLE__NAMESPACE
                   value: NAMESPACE
                 - name: OCTOPUS__K8STENTACLE__PODSERVICEACCOUNTNAME

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -108,16 +108,28 @@ tests:
       path: spec.template.spec.containers[0].env[?(@.name == 'TargetRole')].value
       value: "web,admin"
 
-- it: "Sets worker pools"
+- it: "Sets worker pools if worker enabled"
   set:
     agent:
       worker:
+        enabled: true
         initial:
           workerPools: [WorkerPools-3, MyAwesomeWorkerPool]
   asserts:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'WorkerPools')].value
         value: "WorkerPools-3,MyAwesomeWorkerPool"
+
+- it: "Does not set worker pools if worker disabled"
+  set:
+    agent:
+      worker:
+        enabled: false
+        initial:
+          workerPools: [WorkerPools-3, MyAwesomeWorkerPool]
+  asserts:
+    - notExists:
+        path: spec.template.spec.containers[0].env[?(@.name == 'WorkerPools')].value
 
 - it: "Sets machine policy if specified"
   set:


### PR DESCRIPTION
Small bugfix

When running as a deployment target, we were including an empty `WorkerPools` env var in the tentacle deployment.