### PR TITLE
Add audit archive PVC

### DIFF
--- a/.changeset/tender-dingos-work.md
+++ b/.changeset/tender-dingos-work.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Added audit log PVC

--- a/charts/octopus-deploy/README.md
+++ b/charts/octopus-deploy/README.md
@@ -18,7 +18,7 @@ helm upgrade octopus-deploy \
 --namespace octopus-deploy \
 --create-namespace \
 --set octopus.acceptEula="Y" \
---set octopus.licenseKeyBase64="<Your License Key>"
+--set octopus.licenseKeyBase64="<Your License Key>" \
 --set mssql.enabled="true" \
 oci://ghcr.io/octopusdeploy/octopusdeploy-helm
 ```

--- a/charts/octopus-deploy/templates/pvc.yaml
+++ b/charts/octopus-deploy/templates/pvc.yaml
@@ -57,3 +57,23 @@ spec:
   resources:
     requests:
       storage: {{.Values.octopus.taskLogVolume.size}}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: audit-log-claim
+  labels:
+    {{- include "labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- if (gt (.Values.octopus.replicaCount | int) 1)}}
+    - ReadWriteMany
+    {{- else }}
+    - {{.Values.octopus.taskLogVolume.storageAccessMode}}
+    {{- end }}
+  {{- if $storageClass := (default .Values.global.storageClass .Values.octopus.taskLogVolume.storageClassName) }}
+  storageClassName: {{ $storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{.Values.octopus.taskLogVolume.size}}

--- a/charts/octopus-deploy/templates/pvc.yaml
+++ b/charts/octopus-deploy/templates/pvc.yaml
@@ -69,11 +69,11 @@ spec:
     {{- if (gt (.Values.octopus.replicaCount | int) 1)}}
     - ReadWriteMany
     {{- else }}
-    - {{.Values.octopus.taskLogVolume.storageAccessMode}}
+    - {{.Values.octopus.auditLogVolume.storageAccessMode}}
     {{- end }}
-  {{- if $storageClass := (default .Values.global.storageClass .Values.octopus.taskLogVolume.storageClassName) }}
+  {{- if $storageClass := (default .Values.global.storageClass .Values.octopus.auditLogVolume.storageClassName) }}
   storageClassName: {{ $storageClass }}
   {{- end }}
   resources:
     requests:
-      storage: {{.Values.octopus.taskLogVolume.size}}
+      storage: {{.Values.octopus.auditLogVolume.size}}

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -130,6 +130,8 @@ spec:
             mountPath: /taskLogs
           - name: server-log-volume
             mountPath: /home/octopus/.octopus/OctopusServer/Server/Logs
+          - name: audit-log-volume
+            mountPath: /eventExports
         {{- if .Values.octopus.resources }}
         resources:
 {{ toYaml .Values.octopus.resources | indent 18 }}
@@ -172,6 +174,9 @@ spec:
         - name: task-log-volume
           persistentVolumeClaim:
             claimName: task-log-claim
+        - name: audit-log-volume
+          persistentVolumeClaim:
+            claimName: audit-log-claim
       {{- if .Values.dockerHub.login }}
       imagePullSecrets:
         - name: dockerhubcreds

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -81,6 +81,11 @@ octopus:
     size: 1Gi 
     storageClassName: ""
     storageAccessMode: ReadWriteOnce
+  # Volume used for archived audit logs: https://octopus.com/docs/security/users-and-teams/auditing#archived-audit-events
+  auditLogVolume:
+    size: 1Gi
+    storageClassName: ""
+    storageAccessMode: ReadWriteOnce
 
   service:
     type: NodePort 


### PR DESCRIPTION
Octopus Deploy archives audit events after a configurable amount of time. Previously, this was not mapped as a PVC. This fixes this issue and maps it as a PVC. Details on audit log archiving is available here: https://octopus.com/docs/security/users-and-teams/auditing#archived-audit-events