### PR TITLE
Add security context and server configuration directory values

### DIFF
--- a/.changeset/strange-rings-hunt.md
+++ b/.changeset/strange-rings-hunt.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Add security context and server configuration directory values

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -30,6 +30,10 @@ spec:
       {{ toYaml .Values.octopus.pods.annotations | indent 2 }}
       {{- end }}
     spec:
+      {{- with .Values.octopus.podSecurityContext }}
+      securityContext:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "octopus.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -51,6 +55,9 @@ spec:
       - name: octopus
         image: "{{ .Values.octopus.image.repository }}:{{ default .Chart.AppVersion .Values.octopus.image.tag }}"
         securityContext:
+          {{- with .Values.octopus.containerSecurityContext }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- if .Values.octopus.enableDockerInDocker }}
           privileged: true
           {{- end }}
@@ -61,6 +68,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- if .Values.octopus.serverConfigurationDirectory }}
+          - name: OCTOPUS_SERVER_CONFIGURATION_DIRECTORY
+            value: {{ .Values.octopus.serverConfigurationDirectory }}
+          - name: USER
+            value: octopus
+          {{- end}}
           - name: DB_CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/charts/octopus-deploy/tests/od_statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/od_statefulset_test.yaml
@@ -131,3 +131,47 @@ tests:
           path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels
           value:
             app.kubernetes.io/component: octopus-server
+            
+  - it: podSecurityContext is configurable
+    values:
+      - ./values/required.yaml
+      - ./values/security_context.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 999
+            fsGroupChangePolicy: "OnRootMismatch"
+            runAsGroup: 999
+            runAsNonRoot: true
+            runAsUser: 999
+        documentIndex: 0
+
+  - it: containerSecurityContext is configurable
+    values:
+      - ./values/required.yaml
+      - ./values/security_context.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+        documentIndex: 0
+
+  - it: serverConfigurationDirectory is configurable
+    set:
+      octopus:
+        serverConfigurationDirectory: /home/octopus/.octopus-nonroot/
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "OCTOPUS_SERVER_CONFIGURATION_DIRECTORY")].value
+          value: /home/octopus/.octopus-nonroot/
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == "USER")].value
+          value: octopus
+        documentIndex: 0

--- a/charts/octopus-deploy/tests/values/security_context.yaml
+++ b/charts/octopus-deploy/tests/values/security_context.yaml
@@ -1,0 +1,14 @@
+octopus:
+  enableDockerInDocker: false
+  podSecurityContext:
+    fsGroup: 999
+    fsGroupChangePolicy: "OnRootMismatch"
+    runAsGroup: 999
+    runAsNonRoot: true
+    runAsUser: 999
+  containerSecurityContext:
+    privileged: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -155,6 +155,14 @@ octopus:
             - get
             - watch
             - list
+  # Pod security context settings
+  podSecurityContext: {}
+  # Container security context settings
+  # IMPORTANT: When enableDockerInDocker is true (default), the container must run as privileged.
+  # If setting security contexts that conflict with privileged mode, set enableDockerInDocker to false.
+  containerSecurityContext: {}
+  # Custom directory for Octopus server configuration when using non-root security contexts
+  serverConfigurationDirectory:
 
 dockerHub:
   # Set to true to create a secret containing the docker registry password


### PR DESCRIPTION
Adds 3 new values that can be configured by the user.

1.  Pod security context settings `podSecurityContext`
2. Container security context settings `containerSecurityContext`
3. Custom directory for Octopus server configuration `serverConfigurationDirectory`

[sc-103705]

Fixes https://github.com/OctopusDeploy/helm-charts/issues/378

[Kubernetes docs on configuring security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)