### PR TITLE
Remove bad package manager entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
     "homepage": "https://github.com/OctopusDeploy/helm-charts#readme",
     "directories": {
         "doc": "docs"
-    },
-    "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387"
+    }
 }


### PR DESCRIPTION
Accidentally committed a change to `package.json` which broke our GHAs 😢 
This should work, though we may want to consider using it in future, as it's being added automatically whenever I run `pnpm`