### PR TITLE
Update Github actions/cache version

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -58,7 +58,7 @@ jobs:
         version: v3.13.2
 
     - name: Cache .pnpm-store
-      uses: actions/cache@v3.2.3
+      uses: actions/cache@v4
       with:
         path: ~/.pnpm-store
         key: ${{ runner.os }}-node${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
The version of actions/cache has been deprecated causing the automated versioning workflow to fail
https://github.com/OctopusDeploy/helm-charts/actions/runs/13754003233

v4 of actions/cache is backwards compatible