### PR TITLE
Fix indentation and add indentation tests

### DIFF
--- a/.changeset/silver-wolves-rest.md
+++ b/.changeset/silver-wolves-rest.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": patch
+---
+
+Fix indentation when using multiple annotations or labels

--- a/charts/octopus-deploy/templates/ingress.yaml
+++ b/charts/octopus-deploy/templates/ingress.yaml
@@ -6,13 +6,13 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.octopus.ingress.labels }}
-{{ toYaml .Values.octopus.ingress.labels | indent 4 }}
-{{- end }}
-{{- with .Values.octopus.ingress.annotations }}
-  annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if .Values.octopus.ingress.labels }}
+    {{- toYaml .Values.octopus.ingress.labels | nindent 4 }}
+    {{- end }}
+    {{- with .Values.octopus.ingress.annotations }}
+      annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{- if .Values.octopus.ingress.tls }}
   tls:
@@ -54,20 +54,20 @@ metadata:
   name: octopus-deploy-polling-node{{ . }}
   labels:
     {{- include "labels" $ | nindent 4 }}
-{{- if $.Values.octopus.ingress.pollingTentacles.labels }}
-{{ toYaml $.Values.octopus.ingress.pollingTentacles.labels | indent 4 }}
-{{- end }}
+    {{- if $.Values.octopus.ingress.pollingTentacles.labels }}
+    {{- toYaml $.Values.octopus.ingress.pollingTentacles.labels | nindent 4 }}
+    {{- end }}
   annotations:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-{{- if $.Values.octopus.ingress.pollingTentacles.annotations }}
-{{ toYaml $.Values.octopus.ingress.pollingTentacles.annotations | indent 4 }}
-{{- end }}
+    {{- if $.Values.octopus.ingress.pollingTentacles.annotations }}
+    {{- toYaml $.Values.octopus.ingress.pollingTentacles.annotations | nindent 4 }}
+    {{- end }}
 spec:
   tls:
     - hosts:
-{{- range $.Values.octopus.ingress.hosts }}
-        - {{ printf "%s%d.%s" $.Values.octopus.ingress.pollingTentacles.hostPrefix $replica . | quote }}
-{{- end }}
+      {{- range $.Values.octopus.ingress.hosts }}
+      - {{ printf "%s%d.%s" $.Values.octopus.ingress.pollingTentacles.hostPrefix $replica . | quote }}
+      {{- end }}
   {{- if $.Values.octopus.ingress.className }}
   ingressClassName: {{ $.Values.octopus.ingress.className | quote }}
   {{- end }}

--- a/charts/octopus-deploy/templates/serviceaccount.yaml
+++ b/charts/octopus-deploy/templates/serviceaccount.yaml
@@ -1,17 +1,16 @@
-{{- if .Values.octopus.serviceAccount.create }}
+{{- if .Values.octopus.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- with .Values.octopus.serviceAccount.annotations }}
+  {{- with .Values.octopus.serviceAccount.annotations }}
   annotations:
-{{ tpl (toYaml .) $ | indent 4 }}
-{{- end }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.octopus.serviceAccount.labels }}
-  {{ toYaml .Values.octopus.serviceAccount.labels | indent 2 }}
-  {{- end }}
+    {{- if .Values.octopus.serviceAccount.labels }}
+    {{- toYaml .Values.octopus.serviceAccount.labels | nindent 4 }}
+    {{- end }}
   name: {{ template "octopus.serviceAccountName" . }}
 automountServiceAccountToken: {{ .Values.octopus.serviceAccount.automountServiceAccountToken }}
-{{- end }}
-
+{{- end -}}

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -5,12 +5,12 @@ metadata:
   name: {{ template "octopus.fullname" . }}
   {{- if .Values.octopus.statefulSet.annotations }}
   annotations:
-  {{ toYaml .Values.octopus.statefulSet.annotations | indent 2 }}
+  {{- toYaml .Values.octopus.statefulSet.annotations | nindent 4 }}
   {{- end }}
   labels:
   {{- include "labels" . | nindent 4 }}
   {{- if .Values.octopus.statefulSet.labels }}
-  {{ toYaml .Values.octopus.statefulSet.labels | indent 2 }}
+  {{- toYaml .Values.octopus.statefulSet.labels | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -23,11 +23,11 @@ spec:
       labels:
       {{- include "octopus.selectorLabels" . | nindent 8 }}
       {{- if .Values.octopus.pods.labels }}
-      {{ toYaml .Values.octopus.pods.labels | indent 2 }}
+      {{- toYaml .Values.octopus.pods.labels | nindent 8 }}
       {{- end }}
       {{- if .Values.octopus.pods.annotations }}
       annotations:
-      {{ toYaml .Values.octopus.pods.annotations | indent 2 }}
+      {{- toYaml .Values.octopus.pods.annotations | nindent 8 }}
       {{- end }}
     spec:
       {{- with .Values.octopus.podSecurityContext }}
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ template "octopus.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.octopus.topologySpreadConstraints }}
       topologySpreadConstraints:
@@ -47,10 +47,10 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.octopus.tolerations }}
+      {{- with .Values.octopus.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: octopus
         image: "{{ .Values.octopus.image.repository }}:{{ default .Chart.AppVersion .Values.octopus.image.tag }}"
@@ -147,7 +147,7 @@ spec:
             mountPath: /eventExports
         {{- if .Values.octopus.resources }}
         resources:
-{{ toYaml .Values.octopus.resources | indent 18 }}
+        {{- toYaml .Values.octopus.resources | nindent 10 }}
         {{- end }}
         readinessProbe:
           exec:

--- a/charts/octopus-deploy/tests/od_statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/od_statefulset_test.yaml
@@ -175,3 +175,57 @@ tests:
           path: spec.template.spec.containers[0].env[?(@.name == "USER")].value
           value: octopus
         documentIndex: 0
+
+  - it: labels are configurable
+    values:
+      - ./values/required.yaml
+    set:
+        octopus:
+            pods:
+              labels:
+                  podtest: test1
+                  podtest2: test2
+            statefulSet:
+                labels:
+                    ststest: test1
+                    ststest2: test2
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.podtest
+          value: test1
+      - equal:
+          path: spec.template.metadata.labels.podtest2
+          value: test2
+      - equal:
+          path: metadata.labels.ststest
+          value: test1
+      - equal:
+          path: metadata.labels.ststest2
+          value: test2
+
+  - it: annotations are configurable
+    values:
+      - ./values/required.yaml
+    set:
+      octopus:
+        pods:
+          annotations:
+            example.com/podannotation1: test1
+            example.com/podannotation2: test2
+        statefulSet:
+          annotations:
+            example.com/stsannotation1: test1
+            example.com/stsannotation2: test2
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["example.com/podannotation1"]
+          value: test1
+      - equal:
+          path: spec.template.metadata.annotations["example.com/podannotation2"]
+          value: test2
+      - equal:
+          path: metadata.annotations["example.com/stsannotation1"]
+          value: test1
+      - equal:
+          path: metadata.annotations["example.com/stsannotation2"]
+          value: test2

--- a/charts/octopus-deploy/tests/serviceaccount_test.yaml
+++ b/charts/octopus-deploy/tests/serviceaccount_test.yaml
@@ -1,0 +1,57 @@
+suite: serviceaccount
+templates:
+  - serviceaccount.yaml
+
+tests:
+  - it: serviceaccount should render when enabled
+    values:
+      - ./values/required.yaml
+    set:
+      octopus.serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - hasDocuments:
+          count: 1
+
+  - it: serviceaccount should not render when disabled
+    values:
+      - ./values/required.yaml
+    set:
+      octopus.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: labels are configurable
+    values:
+      - ./values/required.yaml
+    set:
+      octopus.serviceAccount.create: true
+      octopus.serviceAccount.labels:
+        label1: "example"
+        label2: "example2"
+    asserts:
+      - equal:
+          path: metadata.labels.label1
+          value: "example"
+      - equal:
+          path: metadata.labels.label2
+          value: "example2"
+
+  - it: annotations are configurable
+    values:
+      - ./values/required.yaml
+    set:
+      octopus.serviceAccount.create: true
+      octopus.serviceAccount.annotations:
+        example.com/annotation: "example"
+        example.com/annotation2: "example2"
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/annotation"]
+          value: "example"
+      - equal:
+          path: metadata.annotations["example.com/annotation2"]
+          value: "example2"


### PR DESCRIPTION
We received a report that the Octopus Deploy helm chart was not rendering labels correctly. Though labels rendered properly with a single value, if you attempted to set multiple, it would fail due to the usage of `indent` rather than `nindent` and a newline chomp.

This has been resolved on all YAML files and additional tests added to catch this in future. I also cleaned up some of the indentation to read a little better, since the base indentation no longer matters when not using `indent`.