### PR TITLE
Add support for setting annotations on script pods

### DIFF
--- a/.changeset/silent-actors-laugh.md
+++ b/.changeset/silent-actors-laugh.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add support for setting annotations on script pods

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 type: application
 version: "1.22.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.3.2757"
+appVersion: "8.3.2786"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,10 +1,11 @@
 # kubernetes-agent
 
-![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.2757](https://img.shields.io/badge/AppVersion-8.3.2757-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.2786](https://img.shields.io/badge/AppVersion-8.3.2786-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/kubernetes/targets/kubernetes-agent)
 
 ## Maintainers
@@ -31,7 +32,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.defaultNamespace | string | `""` | The default Kubernetes namespace for deployments |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.3.2757","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.3.2786","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
@@ -85,6 +86,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image. If left blank, will use the `octopusdeploy/kubernetes-agent-tools-base` image. |
 | scriptPods.logging.disablePodEventsInTaskLog | bool | `false` | Disables script pod events being written to Octopus Server task log |
+| scriptPods.metadata | object | `{"annotations":{}}` | Additional metadata to add to script pods |
 | scriptPods.resources | object | `{"requests":{"cpu":"25m","memory":"100Mi"}}` | The resource limits and requests assigned to script pod containers |
 | scriptPods.securityContext | object | `{}` | The security context to apply to the script pods |
 | scriptPods.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,5 @@
 # kubernetes-agent
 
-
 ![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.2786](https://img.shields.io/badge/AppVersion-8.3.2786-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 A Helm chart for the Octopus Kubernetes Agent

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -119,6 +119,10 @@ spec:
             - name: "OCTOPUS__K8STENTACLE__PODSECURITYCONTEXTJSON"
               value: {{ . | toJson | quote }}
             {{- end }}
+            {{- with .Values.scriptPods.metadata.annotations }}
+            - name: "OCTOPUS__K8STENTACLE__PODANNOTATIONSJSON"
+              value: {{ . | toJson | quote }}
+            {{- end }}
             {{- if or .Values.agent.serverApiKey .Values.agent.serverApiKeySecretName }}
             - name: "ServerApiKey"
               valueFrom:

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2757
+        app.kubernetes.io/version: 8.3.2786
         helm.sh/chart: kubernetes-agent-1.22.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2757
+        app.kubernetes.io/version: 8.3.2786
         helm.sh/chart: kubernetes-agent-1.22.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2757
+        app.kubernetes.io/version: 8.3.2786
         helm.sh/chart: kubernetes-agent-1.22.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.3.2757
+            app.kubernetes.io/version: 8.3.2786
             helm.sh/chart: kubernetes-agent-1.22.0
         spec:
           affinity:
@@ -100,7 +100,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.3.2757
+              image: octopusdeploy/kubernetes-agent-tentacle:8.3.2786
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2757
+        app.kubernetes.io/version: 8.3.2786
         helm.sh/chart: kubernetes-agent-1.22.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2757
+        app.kubernetes.io/version: 8.3.2786
         helm.sh/chart: kubernetes-agent-1.22.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -397,6 +397,18 @@ tests:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODSECURITYCONTEXTJSON')].value
         value: '{"fsGroup":99,"runAsGroup":431,"runAsUser":1234}'
 
+- it: Sets pod annotations json if script pod metadata.annotations defined
+  set:
+    scriptPods:
+      metadata:
+        annotations:
+          "octopus.com/value-1": "heres-a-value"
+          "octopus.com/value-2": "do-a-thing"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODANNOTATIONSJSON')].value
+        value: '{"octopus.com/value-1":"heres-a-value","octopus.com/value-2":"do-a-thing"}'
+
 - it: "Has the script pods disablePodEventsInTaskLog env var set"
   set:
     scriptPods:

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -266,4 +266,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.2757-bullseye-slim"
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.2786-bullseye-slim"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -103,7 +103,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.3.2757"
+    tag: "8.3.2786"
     tagSuffix: ""
   
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures. 
@@ -171,6 +171,11 @@ scriptPods:
   # -- If true, the script pods will be created with a disruption budget to prevent them from being evicted
   # @section -- Script pod values
   disruptionBudgetEnabled: true
+
+  # -- Additional metadata to add to script pods
+  # @section -- Script pod values
+  metadata:
+    annotations: {}
 
   # -- The resource limits and requests assigned to script pod containers
   # @section -- Script pod values


### PR DESCRIPTION
Thanks to @seanson with https://github.com/OctopusDeploy/OctopusTentacle/pull/1071, you can now set annotations on the script pods.

There is a new `scriptPods.metadata.annotations` value that is then passed through to the tentacle container