### PR TITLE
Add ability to bind PVC to a specific PV via volumeName

### DIFF
--- a/.changeset/six-queens-draw.md
+++ b/.changeset/six-queens-draw.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ability to bind PVC to specific PV via a volumeName

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the Octopus Kubernetes Agent
 
-**Homepage:** <https://octopus.com> 
+**Homepage:** <https://octopus.com>  
 **Documentation:** [https://octopus.com/docs/](https://octopus.com/docs/kubernetes/targets/kubernetes-agent)
 
 ## Maintainers
@@ -76,6 +76,7 @@ A Helm chart for the Octopus Kubernetes Agent
 | persistence.nfs.watchdog.timeout_seconds | string | `""` | The total time to retry failed NFS checks before giving up and deleting the pod @default 10 |
 | persistence.size | string | `"10Gi"` | The size of the volume to create |
 | persistence.storageClassName | string | `""` | if provided, will disable the default persistence configuration and create a PVC with the provided storage class |
+| persistence.volumeName | string | `""` | if provided, will disable the default persistence configuration and create a PVC that is bound directly to the named PersistentVolume |
 
 ### Script pod values
 

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -121,11 +121,23 @@ The name of the secret to store the agent's base64 certificate
 {{- printf "%s-tentacle-certificate" ( include "kubernetes-agent.name" . ) }}
 {{- end }}
 
+
+{{/*
+A value indicating if a custom PVC is being used (and thus the default storage should be disabled)
+*/}}
+{{- define "kubernetes-agent.useCustomPvc" -}}
+{{- if or .Values.persistence.storageClassName .Values.persistence.volumeName }}
+{{- "true" }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}
+
 {{/*
 The name of the PersistentVolumeClaim to configure
 */}}
 {{- define "kubernetes-agent.pvcName" -}}
-{{- if .Values.persistence.storageClassName }}
+{{- if (include "kubernetes-agent.useCustomPvc" .) }}
 {{- printf "%s-pvc" (include "kubernetes-agent.fullName" .) }}
 {{- else }}
 {{- include "nfs.pvcName" . }}

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.storageClassName }}
+{{- if not (include "kubernetes-agent.useCustomPvc" .) }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/charts/kubernetes-agent/templates/nfs-pvc.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.storageClassName }}
+{{- if not (include "kubernetes-agent.useCustomPvc" .) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/kubernetes-agent/templates/nfs-service.yaml
+++ b/charts/kubernetes-agent/templates/nfs-service.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.storageClassName }}
+{{- if not (include "kubernetes-agent.useCustomPvc" .) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.storageClassName }}
+{{- if not (include "kubernetes-agent.useCustomPvc" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/kubernetes-agent/templates/pod-clusterroles.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterroles.yaml
@@ -17,7 +17,7 @@ rules:
   verbs:
   - '*'
 {{- end }}
-{{- if and .Values.persistence.nfs.watchdog.enabled (not .Values.persistence.storageClassName)}}
+{{- if and .Values.persistence.nfs.watchdog.enabled (not (include "kubernetes-agent.useCustomPvc" .)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kubernetes-agent/templates/pod-rolebindings.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebindings.yaml
@@ -19,7 +19,7 @@ roleRef:
   name: {{ $podClusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
-{{- if and .Values.persistence.nfs.watchdog.enabled (not .Values.persistence.storageClassName)}}
+{{- if and .Values.persistence.nfs.watchdog.enabled (not (include "kubernetes-agent.useCustomPvc" .)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -89,7 +89,7 @@ spec:
               value: {{ .Values.agent.debug.disableAutoPodCleanup | quote }}
             - name: "OCTOPUS__K8STENTACLE__DISABLEPODEVENTSINTASKLOG"
               value: {{ .Values.scriptPods.logging.disablePodEventsInTaskLog | quote }}
-            {{- if and .Values.persistence.nfs.watchdog.enabled (not .Values.persistence.storageClassName) }}
+            {{- if and .Values.persistence.nfs.watchdog.enabled (not (include "kubernetes-agent.useCustomPvc" .)) }}
             - name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
               value: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
             {{- end }}
@@ -192,7 +192,7 @@ spec:
               subPath: octopus-server-certificate.pem
               readOnly: false
             {{- end }}
-        {{- if and .Values.persistence.nfs.watchdog.enabled (not .Values.persistence.storageClassName) }}
+        {{- if and .Values.persistence.nfs.watchdog.enabled (not (include "kubernetes-agent.useCustomPvc" .)) }}
         - name: nfs-watchdog
           image: "{{ .Values.persistence.nfs.watchdog.image.repository }}:{{ .Values.persistence.nfs.watchdog.image.tag }}"
           imagePullPolicy: {{ .Values.persistence.nfs.watchdog.image.pullPolicy }}

--- a/charts/kubernetes-agent/templates/tentacle-pvc.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.storageClassName }}
+{{- if (include "kubernetes-agent.useCustomPvc" .) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -8,7 +8,12 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}  
+  {{- with .Values.persistence.volumeName }}
+  volumeName: {{ . | quote }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size}}

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -17,3 +17,22 @@ should match snapshot when storageClassName is set:
         requests:
           storage: 10Gi
       storageClassName: my-storage-class
+should match snapshot when volumeName is set:
+  1: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: octopus-agent
+        app.kubernetes.io/version: 8.3.2786
+        helm.sh/chart: kubernetes-agent-1.23.0
+      name: octopus-agent-RELEASE-NAME-pvc
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: 10Gi
+      volumeName: my-volume

--- a/charts/kubernetes-agent/tests/nfs-pv_test.yaml
+++ b/charts/kubernetes-agent/tests/nfs-pv_test.yaml
@@ -14,10 +14,19 @@ tests:
   - hasDocuments:
       count: 0
 
-- it: "is created when storageClassName is empty"
+- it: "is not created when volumeName has a value"
+  set:
+    persistence:
+      volumeName: "value"
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: "is created when storageClassName and volumeName are empty"
   set:
     persistence:
       storageClassName: ""
+      volumeName: ""
   asserts:
   - hasDocuments:
       count: 1

--- a/charts/kubernetes-agent/tests/nfs-pvc_test.yaml
+++ b/charts/kubernetes-agent/tests/nfs-pvc_test.yaml
@@ -13,10 +13,19 @@ tests:
   - hasDocuments:
       count: 0
 
-- it: "is created when storageClassName is empty"
+- it: "is not created when volumeName has a value"
+  set:
+    persistence:
+      volumeName: "value"
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: "is created when storageClassName and volumeName are empty"
   set:
     persistence:
       storageClassName: ""
+      volumeName: ""
   asserts:
   - hasDocuments:
       count: 1

--- a/charts/kubernetes-agent/tests/nfs-statefulset_test.yaml
+++ b/charts/kubernetes-agent/tests/nfs-statefulset_test.yaml
@@ -10,6 +10,14 @@ tests:
   - hasDocuments:
       count: 0
 
+- it: "is not created when volumeName has a value"
+  set:
+    persistence:
+      volumeName: "value"
+  asserts:
+  - hasDocuments:
+      count: 0
+
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -38,10 +38,39 @@ tests:
           path: spec.template.spec.containers[1].image
           value: "octopusdeploy/kubernetes-agent-nfs-watchdog:0.0.1"
 
-  - it: "Doesn't include the watchdog when only the Watchdog is enabled"
+  - it: "Doesn't include the watchdog when only the Watchdog is enabled and storageClassName is set"
     set:
       persistence:
         storageClassName: "my-thing"
+        nfs:
+          watchdog:
+            enabled: true
+            image:
+              repository: octopusdeploy/kubernetes-agent-nfs-watchdog
+              tag: "0.0.1"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: octopus-agent-tentacle
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "OCTOPUS__K8STENTACLE__NFSWATCHDOGIMAGE"
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: "nfs-watchdog"
+
+  - it: "Doesn't include the watchdog when only the Watchdog is enabled and volumeName is set"
+    set:
+      persistence:
+        volumeName: "my-thing"
         nfs:
           watchdog:
             enabled: true

--- a/charts/kubernetes-agent/tests/tentacle-pvc_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-pvc_test.yaml
@@ -8,6 +8,14 @@ tests:
       storageClassName: "my-storage-class"
   asserts:
     - matchSnapshot: {}
+
+- it: "should match snapshot when volumeName is set"
+  set:
+    persistence:
+      volumeName: "my-volume"
+  asserts:
+    - matchSnapshot: {}
+
 - it: "is not created when storageClassName is empty"
   set:
     persistence:
@@ -20,6 +28,14 @@ tests:
   set:
     persistence:
       storageClassName: "my-storage-class"
+  asserts:
+  - hasDocuments:
+      count: 1
+
+- it: "is created when volumeName has a value"
+  set:
+    persistence:
+      volumeName: "my-storage-class"
   asserts:
   - hasDocuments:
       count: 1

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -247,6 +247,10 @@ persistence:
   # @section -- Persistence
   storageClassName: ""
 
+  # -- if provided, will disable the default persistence configuration and create a PVC that is bound directly to the named PersistentVolume
+  # @section -- Persistence
+  volumeName: ""
+
   # -- The size of the volume to create
   # @section -- Persistence
   size: 10Gi


### PR DESCRIPTION
We have had requests from customers to be able to specify a specific `volumeName` when using a custom PVC