### PR TITLE
Upgrade kubernetes-monitor chart to v0.13.0

### DIFF
--- a/.changeset/shaky-spies-invite.md
+++ b/.changeset/shaky-spies-invite.md
@@ -1,0 +1,8 @@
+---
+"kubernetes-agent": patch
+---
+
+Upgrade kubernetes-monitor chart to v0.13.0
+
+Kubernetes monitor changes:
+- fix: Invalidate k8s discovery cache more frequently to detect new CRDs

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.12.0
-digest: sha256:eaf69569a20472d98131d55604c34277436ad1d53ba36177999a2744aa7bfa91
-generated: "2025-05-13T10:45:18.47116+10:00"
+  version: 0.13.0
+digest: sha256:ec7e382a07f8ada743e6fea16bc41d67b37662621c6caa6a1626cf9255ba7b73
+generated: "2025-05-22T10:44:54.093622+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.12.0"
+    version: "0.13.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
While we still don't have the Kubernetes monitor release notes public, I'm going to start including them in agent patch notes so customers know what we are changing.