### PR TITLE
Update tentacle to 8.3.3034

### DIFF
--- a/.changeset/beige-steaks-knock.md
+++ b/.changeset/beige-steaks-knock.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Update Tentacle to 8.3.3034 to fix an issue with fallback container tags and newer versions of Kubernetes.

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "2.17.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.3.2786"
+appVersion: "8.3.3034"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.17.0](https://img.shields.io/badge/Version-2.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.2786](https://img.shields.io/badge/AppVersion-8.3.2786-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.17.0](https://img.shields.io/badge/Version-2.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.3034](https://img.shields.io/badge/AppVersion-8.3.3034-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -52,7 +52,7 @@ The Kubernetes agent is optionally installed alongside the Kubernetes agent, [re
 | agent.certificate | string | `""` | A base64-encoded x509 certificate used to setup a trust between the agent and target Octopus Server |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.3.2786","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"8.3.3034","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.3.2786
+            app.kubernetes.io/version: 8.3.3034
             helm.sh/chart: kubernetes-agent-2.17.0
         spec:
           affinity:
@@ -104,7 +104,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:8.3.2786
+              image: octopusdeploy/kubernetes-agent-tentacle:8.3.3034
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:
@@ -26,7 +26,7 @@ should match snapshot when volumeName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.2786
+        app.kubernetes.io/version: 8.3.3034
         helm.sh/chart: kubernetes-agent-2.17.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -295,4 +295,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.2786-bullseye-slim"
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.3034-bullseye-slim"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -117,7 +117,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "8.3.2786"
+    tag: "8.3.3034"
     tagSuffix: ""
   
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures. 


### PR DESCRIPTION
Updates the `kubernetes-tentacle` container to `8.3.3034` to pick up the fix made in:

- https://github.com/OctopusDeploy/OctopusTentacle/pull/1111