### PR TITLE
chore: update Kubernetes monitor chart to 0.14.0

### DIFF
--- a/.changeset/hungry-tigers-draw.md
+++ b/.changeset/hungry-tigers-draw.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Updated the Kubernetes Monitor chart to 0.14.0

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.13.0
-digest: sha256:ec7e382a07f8ada743e6fea16bc41d67b37662621c6caa6a1626cf9255ba7b73
-generated: "2025-05-22T10:44:54.093622+10:00"
+  version: 0.14.0
+digest: sha256:a052cb0f829ba269721abe45a8f4aed1118c9770753e3a455654726801940e31
+generated: "2025-06-26T09:04:27.455507+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.13.0"
+    version: "0.14.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
This PR releases 0.14.0 of the Kubernetes agent chart, which includes 0.15.2 of the Kubernetes monitor.