### PR TITLE
feat: add extra env variables to octopus server chart

### DIFF
--- a/.changeset/fresh-cobras-obey.md
+++ b/.changeset/fresh-cobras-obey.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Add extraEnv to add environment variables to the container

--- a/charts/octopus-deploy/.gitignore
+++ b/charts/octopus-deploy/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the helm unittest debug output
+.debug

--- a/charts/octopus-deploy/templates/_helpers.tpl
+++ b/charts/octopus-deploy/templates/_helpers.tpl
@@ -143,3 +143,13 @@ Templates out the database connection string to be used if the mssql subchart is
 {{- required "When not using the default in-cluster db (mssql.enabled=true), database connection string must be provided" .Values.octopus.databaseConnectionString -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Templates out extra environment variables to be used
+*/}}
+{{- define "octopus.extraEnv" -}}
+{{- if .Values.octopus.extraEnv -}}
+{{- toYaml .Values.octopus.extraEnv -}}
+{{- end -}}
+{{- end -}}

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -62,6 +62,7 @@ spec:
           privileged: true
           {{- end }}
         env:
+          {{- include "octopus.extraEnv" . | nindent 10 }}
           - name: ACCEPT_EULA
             value: {{ template "octopus.acceptEulaStr" . }} 
           - name: OCTOPUS_SERVER_NODE_NAME

--- a/charts/octopus-deploy/tests/od_statefulset_test.yaml
+++ b/charts/octopus-deploy/tests/od_statefulset_test.yaml
@@ -229,3 +229,26 @@ tests:
       - equal:
           path: metadata.annotations["example.com/stsannotation2"]
           value: test2
+  - it: extraEnv is configurable
+    values:
+      - ./values/required.yaml
+    set:
+      octopus:
+        extraEnv:
+          - name: EXAMPLE_ENV_VAR
+            value: example_value
+          - name: ANOTHER_ENV_VAR
+            valueFrom:
+              secretKeyRef:
+                name: example-secret
+                key: example-key
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'EXAMPLE_ENV_VAR')].value
+          value: example_value
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'ANOTHER_ENV_VAR')].valueFrom.secretKeyRef.name
+          value: example-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[?(@.name == 'ANOTHER_ENV_VAR')].valueFrom.secretKeyRef.key
+          value: example-key

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -164,6 +164,17 @@ octopus:
   # Custom directory for Octopus server configuration when using non-root security contexts
   serverConfigurationDirectory:
 
+  # Extra environment variables to set in the Octopus server container
+  # Example:
+  # extraEnv:
+  # - name: HTTPS_PROXY
+  #   value: http://example.com:3128
+  # - name: POD_NAME
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.name
+  extraEnv: []
+
 dockerHub:
   # Set to true to create a secret containing the docker registry password
   login: false


### PR DESCRIPTION
This PR adds the ability to define extra environment variables in the octopus server helm chart, as well as adding tests to validate its use. Note that duplicating environment variables already existing in the chart may lead to undefined behaviour (likely a failure to apply in Kubernetes).