### PR TITLE
feat: allow custom accessModes - for dev and testing purposes only

### DIFF
--- a/.changeset/fancy-teams-type.md
+++ b/.changeset/fancy-teams-type.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Added custom access modes (for testing and dev purposes only)

--- a/charts/kubernetes-agent/templates/nfs-pv.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pv.yaml
@@ -9,7 +9,7 @@ spec:
   capacity:
     storage: {{ .Values.persistence.size }}
   accessModes:
-    - ReadWriteMany
+    {{- .Values.persistence.accessModes | toYaml | nindent 4 }}
   persistentVolumeReclaimPolicy: Retain
   storageClassName: {{ include "nfs.storageClassName" . }}
   mountOptions:

--- a/charts/kubernetes-agent/templates/nfs-pvc.yaml
+++ b/charts/kubernetes-agent/templates/nfs-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "nfs.pvcName" . }} 
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- .Values.persistence.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.persistence.size}}

--- a/charts/kubernetes-agent/templates/tentacle-pvc.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-pvc.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubernetes-agent.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteMany
+    {{- .Values.persistence.accessModes | toYaml | nindent 4 }}
   {{- with .Values.persistence.storageClassName }}
   storageClassName: {{ . | quote }}
   {{- end }}  

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -292,6 +292,11 @@ persistence:
   # @section -- Persistence
   storageClassName: ""
 
+  # -- if provided, will set the access modes for the persistent volume claim
+  # Should not be used under normal circumstances, and cannot be changed once set
+  # @ignored
+  accessModes: ["ReadWriteMany"]
+
   # -- if provided, will disable the default persistence configuration and create a PVC that is bound directly to the named PersistentVolume
   # @section -- Persistence
   volumeName: ""


### PR DESCRIPTION
This PR adds the ability to customise the PV/PVC access modes, which will allow local development using `ReadWriteOnce` volumes (since we only have a single node in many dev environments).