### PR TITLE
feat: Add ability to define additional labels to the script pods

### DIFF
--- a/.changeset/free-shoes-mix.md
+++ b/.changeset/free-shoes-mix.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ability to define additional labels to the script pods

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "2.19.1"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "8.3.3034"
+appVersion: "8.3.3103"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.3034](https://img.shields.io/badge/AppVersion-8.3.3034-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.3103](https://img.shields.io/badge/AppVersion-8.3.3103-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -135,7 +135,7 @@ The Kubernetes agent is optionally installed alongside the Kubernetes agent, [re
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.logging.disablePodEventsInTaskLog | bool | `false` | Disables script pod events being written to Octopus Server task log |
-| scriptPods.metadata | object | `{"annotations":{}}` | Additional metadata to add to script pods |
+| scriptPods.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to script pods |
 | scriptPods.proxies.http_proxy | string | `""` | The URI of the HTTP proxy server to be used during script operations |
 | scriptPods.proxies.https_proxy | string | `""` | The URI of the HTTPS proxy server to be used during script operations |
 | scriptPods.proxies.no_proxy | string | `""` | A comma-separated list of host names or IP addresses that should not go through any proxy |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -135,6 +135,10 @@ spec:
             - name: "OCTOPUS__K8STENTACLE__PODANNOTATIONSJSON"
               value: {{ . | toJson | quote }}
             {{- end }}
+            {{- with .Values.scriptPods.metadata.labels }}
+            - name: "OCTOPUS__K8STENTACLE__PODLABELSJSON"
+              value: {{ . | toJson | quote }}
+            {{- end }}
             {{ if (include "kubernetes-agent.scriptPodProxies" .) }}
             - name: "OCTOPUS__K8STENTACLE__PODPROXIESSECRETNAME"
               value: "scripts-proxies"

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 8.3.3034
+            app.kubernetes.io/version: 8.3.3103
             helm.sh/chart: kubernetes-agent-2.19.1
         spec:
           affinity:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-RELEASE-NAME-pvc
     spec:
@@ -26,7 +26,7 @@ should match snapshot when volumeName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 8.3.3034
+        app.kubernetes.io/version: 8.3.3103
         helm.sh/chart: kubernetes-agent-2.19.1
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -520,3 +520,15 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__KUBERNETESMONITORENABLED')].value
         value: "true"
+
+- it: Sets pod labels json if script pod metadata.labels defined
+  set:
+    scriptPods:
+      metadata:
+        labels:
+          "azure.workload.identity/use": "true"
+          "octopus.com/value-2": "also-true"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__PODLABELSJSON')].value
+        value: '{"azure.workload.identity/use":"true","octopus.com/value-2":"also-true"}'

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -295,4 +295,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.3034-bullseye-slim"
+          value: "octopusdeploy/kubernetes-agent-tentacle:8.3.3103-bullseye-slim"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -200,6 +200,7 @@ scriptPods:
   # @section -- Script pod values
   metadata:
     annotations: {}
+    labels: {}
 
   # -- The resource limits and requests assigned to script pod containers
   # @section -- Script pod values


### PR DESCRIPTION
# Background
This PR adds the ability to define extra labels on the script pods, which is required to support [Entra workload identities](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels).

# Results
Fixes: https://github.com/OctopusDeploy/Issues/issues/9543

# Note
This PR needs https://github.com/OctopusDeploy/OctopusTentacle/pull/1115 to be merged and added as the appVersion to work correctly. 