### PR TITLE
Add namespaced roles

### DIFF
--- a/.changeset/hungry-readers-call.md
+++ b/.changeset/hungry-readers-call.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add ability to install without any clusterroles or clusterrolebindings

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -108,6 +108,13 @@ The Kubernetes agent is optionally installed alongside the Kubernetes agent, [re
 |-----|------|---------|-------------|
 | agent.worker.initial.workerPools | list | `[]` | The worker pools to associate with the worker |
 
+### Auto-upgrader configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| autoUpgrader.selfNamespaceRoleRules | list | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]` | Rules for managing the agent in its own namespace when using namespace-scoped roles |
+| autoUpgrader.targetNamespaceRoleRules | list | `[{"apiGroups":["rbac.authorization.k8s.io"],"resources":["roles","rolebindings"],"verbs":["create","update","patch","get","list","watch","delete"]},{"apiGroups":["rbac.authorization.k8s.io"],"resources":["roles"],"verbs":["escalate"]}]` | Rules for managing script pod roles in target namespaces when using namespace-scoped roles |
+
 ### Persistence
 
 | Key | Type | Default | Description |
@@ -144,7 +151,9 @@ The Kubernetes agent is optionally installed alongside the Kubernetes agent, [re
 | scriptPods.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | scriptPods.serviceAccount.clusterRole | object | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]},{"nonResourceURLs":["*"],"verbs":["*"]}]` | if defined, overrides the default ClusterRole rules |
 | scriptPods.serviceAccount.name | string | `""` | The name of the service account used for executing script pods |
+| scriptPods.serviceAccount.roleRules | list | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]` | if defined, overrides the default Role rules when using namespace-scoped roles |
 | scriptPods.serviceAccount.targetNamespaces | list | Uses a ClusterRoleBinding to allow the service account to run in any namespace | Specifies that the pod service account should be constrained to target namespaces |
+| scriptPods.serviceAccount.useNamespacedRoles | bool | `false` | Use namespace-scoped Roles instead of ClusterRoles |
 | scriptPods.tolerations | list | `[]` | The tolerations to apply to script pods |
 | scriptPods.worker.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/worker-tools","tag":"ubuntu.22.04"}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a worker |
 

--- a/charts/kubernetes-agent/templates/_helpers.tpl
+++ b/charts/kubernetes-agent/templates/_helpers.tpl
@@ -117,6 +117,27 @@ Create the name of the pod cluster role binding to use
 {{- end }}
 
 {{/*
+Create the name of the pod role (namespace-scoped) to use
+*/}}
+{{- define "kubernetes-agent.scriptPodRoleName" -}}
+{{- printf "%s-role" (include "kubernetes-agent.scriptPodServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
+Create the name of the auto upgrader self-namespace role
+*/}}
+{{- define "kubernetes-agent.autoUpgraderSelfRoleName" -}}
+{{- printf "%s-self-role" (include "kubernetes-agent.autoUpgraderServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
+Create the name of the auto upgrader target-namespace role
+*/}}
+{{- define "kubernetes-agent.autoUpgraderTargetRoleName" -}}
+{{- printf "%s-target-role" (include "kubernetes-agent.autoUpgraderServiceAccountFullName" .) }}
+{{- end }}
+
+{{/*
 The name of the secret to store the authentication information (bearer token/api key)
 */}}
 {{- define "kubernetes-agent.secrets.serverAuth" -}}

--- a/charts/kubernetes-agent/templates/auto-upgrader-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-clusterbinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.scriptPods.serviceAccount.useNamespacedRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "kubernetes-agent.autoUpgraderClusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/kubernetes-agent/templates/auto-upgrader-clusterrole.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.scriptPods.serviceAccount.useNamespacedRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6,3 +7,4 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["*"]
+{{- end }}

--- a/charts/kubernetes-agent/templates/auto-upgrader-rolebindings.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-rolebindings.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.scriptPods.serviceAccount.useNamespacedRoles }}
+{{- $autoUpgraderServiceAccountName := include "kubernetes-agent.autoUpgraderServiceAccountName" . -}}
+{{- $autoUpgraderSelfRoleName := include "kubernetes-agent.autoUpgraderSelfRoleName" . -}}
+{{- $autoUpgraderTargetRoleName := include "kubernetes-agent.autoUpgraderTargetRoleName" . -}}
+
+# RoleBinding for managing the agent in its own namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-self-binding" $autoUpgraderServiceAccountName }}
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $autoUpgraderServiceAccountName }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ $autoUpgraderSelfRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+
+{{- if .Values.scriptPods.serviceAccount.targetNamespaces }}
+# RoleBindings for managing script pod roles/rolebindings in target namespaces
+{{- range $targetNamespace := $.Values.scriptPods.serviceAccount.targetNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-target-binding" $autoUpgraderServiceAccountName }}
+  namespace: {{ $targetNamespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $autoUpgraderServiceAccountName }}
+  namespace: {{ $.Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ $autoUpgraderTargetRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/auto-upgrader-roles.yaml
+++ b/charts/kubernetes-agent/templates/auto-upgrader-roles.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.scriptPods.serviceAccount.useNamespacedRoles }}
+{{- $autoUpgraderSelfRoleName := include "kubernetes-agent.autoUpgraderSelfRoleName" . -}}
+{{- $autoUpgraderTargetRoleName := include "kubernetes-agent.autoUpgraderTargetRoleName" . -}}
+
+# Role for managing the agent in its own namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $autoUpgraderSelfRoleName }}
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+{{- if .Values.autoUpgrader.selfNamespaceRoleRules }}
+{{ .Values.autoUpgrader.selfNamespaceRoleRules | toYaml | nindent 2 }}
+{{- else }}
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+{{- end }}
+
+{{- if .Values.scriptPods.serviceAccount.targetNamespaces }}
+# Roles for managing script pod roles/rolebindings in target namespaces
+{{- range $targetNamespace := $.Values.scriptPods.serviceAccount.targetNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $autoUpgraderTargetRoleName }}
+  namespace: {{ $targetNamespace | quote }}
+rules:
+{{- if $.Values.autoUpgrader.targetNamespaceRoleRules }}
+{{ $.Values.autoUpgrader.targetNamespaceRoleRules | toYaml | nindent 2 }}
+{{- else }}
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles"]
+  {{/* escalate verb allows us to create roles/rolebindings in this namespace with correct permissions */}}
+  verbs: ["escalate"]
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterbinding.yaml
@@ -1,4 +1,4 @@
-{{- if  and (empty .Values.scriptPods.serviceAccount.targetNamespaces) (not .Values.agent.worker.enabled) }}
+{{- if  and (empty .Values.scriptPods.serviceAccount.targetNamespaces) (not .Values.agent.worker.enabled) (not .Values.scriptPods.serviceAccount.useNamespacedRoles) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/kubernetes-agent/templates/pod-clusterroles.yaml
+++ b/charts/kubernetes-agent/templates/pod-clusterroles.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.scriptPods.serviceAccount.useNamespacedRoles }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,4 +32,5 @@ rules:
     verbs:
       - 'delete'
       - 'list'
+{{- end }}
 {{- end }}

--- a/charts/kubernetes-agent/templates/pod-rolebindings.yaml
+++ b/charts/kubernetes-agent/templates/pod-rolebindings.yaml
@@ -1,6 +1,7 @@
 {{- $podServiceAccountName := include "kubernetes-agent.scriptPodServiceAccountName" . -}}
 {{- $podServiceAccountFullName := include "kubernetes-agent.scriptPodServiceAccountFullName" . -}}
 {{- $podClusterRoleName := include "kubernetes-agent.scriptPodClusterRoleName" . -}}
+{{- $podRoleName := include "kubernetes-agent.scriptPodRoleName" . -}}
 {{- $podDeleterClusterRoleName := include "kubernetes-agent.scriptPodDeleterClusterRoleName" . -}}  
 
 {{- if .Values.agent.deploymentTarget.enabled }}
@@ -16,8 +17,13 @@ subjects:
   name: {{ $podServiceAccountName }}
   namespace: {{ $.Release.Namespace | quote }}
 roleRef:
+  {{- if $.Values.scriptPods.serviceAccount.useNamespacedRoles }}
+  kind: Role
+  name: {{ $podRoleName }}
+  {{- else }}
   kind: ClusterRole
   name: {{ $podClusterRoleName }}
+  {{- end }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
 {{- end -}}

--- a/charts/kubernetes-agent/templates/pod-roles.yaml
+++ b/charts/kubernetes-agent/templates/pod-roles.yaml
@@ -1,3 +1,18 @@
+{{- if .Values.agent.worker.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kubernetes-agent.scriptPodWorkerRoleName" . }}
+  namespace: {{ $.Release.Namespace | quote }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+{{- end -}}
+
 {{- $podServiceAccountName := include "kubernetes-agent.scriptPodServiceAccountName" . -}}
 {{- $podServiceAccountFullName := include "kubernetes-agent.scriptPodServiceAccountFullName" . -}}
 {{- $podRoleName := include "kubernetes-agent.scriptPodRoleName" . -}}

--- a/charts/kubernetes-agent/templates/pod-roles.yaml
+++ b/charts/kubernetes-agent/templates/pod-roles.yaml
@@ -1,14 +1,25 @@
-{{- if .Values.agent.worker.enabled }}
+{{- $podServiceAccountName := include "kubernetes-agent.scriptPodServiceAccountName" . -}}
+{{- $podServiceAccountFullName := include "kubernetes-agent.scriptPodServiceAccountFullName" . -}}
+{{- $podRoleName := include "kubernetes-agent.scriptPodRoleName" . -}}
+
+{{- if and .Values.scriptPods.serviceAccount.useNamespacedRoles .Values.scriptPods.serviceAccount.targetNamespaces }}
+{{- range $targetNamespace := $.Values.scriptPods.serviceAccount.targetNamespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kubernetes-agent.scriptPodWorkerRoleName" . }}
-  namespace: {{ $.Release.Namespace | quote }}
+  name: {{ $podRoleName }}
+  namespace: {{ $targetNamespace | quote }}
 rules:
+{{- if $.Values.scriptPods.serviceAccount.roleRules }}
+{{ $.Values.scriptPods.serviceAccount.roleRules | toYaml | nindent 2 }}
+{{- else }}
 - apiGroups:
   - '*'
   resources:
   - '*'
   verbs:
   - '*'
-  {{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kubernetes-agent/tests/auto-upgrader-clusterbinding_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-clusterbinding_test.yaml
@@ -5,3 +5,12 @@ tests:
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}
+
+- it: "is not created when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/kubernetes-agent/tests/auto-upgrader-clusterrole_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-clusterrole_test.yaml
@@ -5,3 +5,12 @@ tests:
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}
+
+- it: "is not created when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/kubernetes-agent/tests/auto-upgrader-rolebindings_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-rolebindings_test.yaml
@@ -1,0 +1,67 @@
+suite: "auto-upgrader namespace-scoped rolebindings"
+templates:
+- templates/auto-upgrader-rolebindings.yaml
+tests:
+- it: "is not created when useNamespacedRoles is false"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: false
+        targetNamespaces: ["ns-1", "ns-2"]
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: "creates self-namespace rolebinding when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: []
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: kind
+      value: RoleBinding
+  - equal:
+      path: metadata.namespace
+      value: NAMESPACE
+  - equal:
+      path: roleRef.kind
+      value: Role
+
+- it: "creates rolebindings for all namespaces"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1", "ns-2", "ns-3"]
+  asserts:
+  - hasDocuments:
+      count: 4  # 1 self-namespace + 3 target namespaces
+  - equal:
+      path: kind
+      value: RoleBinding
+  - equal:
+      path: subjects[0].kind
+      value: ServiceAccount
+
+- it: "binds to correct roles in each namespace"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1"]
+  asserts:
+  - hasDocuments:
+      count: 2
+  # Just check that both rolebindings exist in correct namespaces
+  - equal:
+      path: kind
+      value: RoleBinding
+      documentIndex: 0
+  - equal:
+      path: kind
+      value: RoleBinding
+      documentIndex: 1

--- a/charts/kubernetes-agent/tests/auto-upgrader-roles_test.yaml
+++ b/charts/kubernetes-agent/tests/auto-upgrader-roles_test.yaml
@@ -1,0 +1,90 @@
+suite: "auto-upgrader namespace-scoped roles"
+templates:
+- templates/auto-upgrader-roles.yaml
+tests:
+- it: "is not created when useNamespacedRoles is false"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: false
+        targetNamespaces: ["ns-1", "ns-2"]
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: "creates self-namespace role when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: []
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: kind
+      value: Role
+  - equal:
+      path: metadata.namespace
+      value: NAMESPACE
+  - contains:
+      path: rules
+      content:
+        apiGroups: ["*"]
+        resources: ["*"]
+        verbs: ["*"]
+
+- it: "creates self-namespace and target namespace roles"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1", "ns-2"]
+  asserts:
+  - hasDocuments:
+      count: 3  # 1 self-namespace + 2 target namespaces
+
+- it: "uses custom selfNamespaceRoleRules when provided"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: []
+    autoUpgrader:
+      selfNamespaceRoleRules:
+      - apiGroups: ["apps"]
+        resources: ["deployments"]
+        verbs: ["get", "update"]
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: rules[0].resources[0]
+      value: deployments
+  - equal:
+      path: rules[0].verbs[0]
+      value: get
+
+- it: "uses custom targetNamespaceRoleRules when provided"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1"]
+    autoUpgrader:
+      targetNamespaceRoleRules:
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        resources: ["roles"]
+        verbs: ["create", "update"]
+  asserts:
+  - hasDocuments:
+      count: 2  # 1 self-namespace + 1 target namespace
+  # Check that both are Roles
+  - equal:
+      path: kind
+      value: Role
+      documentIndex: 0
+  - equal:
+      path: kind  
+      value: Role
+      documentIndex: 1

--- a/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-clusterbinding_test.yaml
@@ -11,6 +11,15 @@ tests:
   - hasDocuments:
       count: 0
 
+- it: "is not created when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+  asserts:
+  - hasDocuments:
+      count: 0
+
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}

--- a/charts/kubernetes-agent/tests/pod-clusteroles_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-clusteroles_test.yaml
@@ -33,3 +33,12 @@ tests:
 - it: "should match snapshot"
   asserts:
   - matchSnapshot: {}
+
+- it: "is not created when useNamespacedRoles is true"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/kubernetes-agent/tests/pod-roles_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-roles_test.yaml
@@ -2,6 +2,26 @@ suite: "pod namespace-scoped roles"
 templates:
 - templates/pod-roles.yaml
 tests:
+- it: "worker role is created if worker is enabled"
+  set:
+    agent.worker.enabled: true
+  asserts:
+    - contains:
+        path: rules
+        content:
+          apiGroups:
+            - '*'
+          resources: [ "*" ]
+          verbs: [ "*" ]
+        documentIndex: 1
+
+- it: "worker role is not created if worker is disabled"
+  set:
+    agent.worker.enabled: false
+  asserts:
+    - hasDocuments:
+        count: 0
+
 - it: "is not created when useNamespacedRoles is false"
   set:
     scriptPods:

--- a/charts/kubernetes-agent/tests/pod-roles_test.yaml
+++ b/charts/kubernetes-agent/tests/pod-roles_test.yaml
@@ -1,23 +1,62 @@
-suite: "pod permissions"
+suite: "pod namespace-scoped roles"
 templates:
-  - templates/pod-roles.yaml
+- templates/pod-roles.yaml
 tests:
-  - it: "worker role is created if worker is enabled"
-    set:
-      agent.worker.enabled: true
-    asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups:
-              - '*'
-            resources: ["*"]
-            verbs: ["*"]
-          documentIndex: 1
+- it: "is not created when useNamespacedRoles is false"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: false
+        targetNamespaces: ["ns-1", "ns-2"]
+  asserts:
+  - hasDocuments:
+      count: 0
 
-  - it: "worker role is not created if worker is disabled"
-    set:
-      agent.worker.enabled: false
-    asserts:
-      - hasDocuments:
-          count: 0
+- it: "is not created when targetNamespaces is empty"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: []
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: "creates roles in each target namespace"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1", "ns-2", "ns-3"]
+  asserts:
+  - hasDocuments:
+      count: 3
+  - equal:
+      path: kind
+      value: Role
+  - contains:
+      path: rules
+      content:
+        apiGroups: ["*"]
+        resources: ["*"]
+        verbs: ["*"]
+
+- it: "uses custom roleRules when provided"
+  set:
+    scriptPods:
+      serviceAccount:
+        useNamespacedRoles: true
+        targetNamespaces: ["ns-1"]
+        roleRules:
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list"]
+  asserts:
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: rules[0].resources[0]
+      value: pods
+  - equal:
+      path: rules[0].verbs[0]
+      value: get

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -398,6 +398,7 @@ autoUpgrader:
       verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
     - apiGroups: ["rbac.authorization.k8s.io"]
       resources: ["roles"]
+      verbs: ["escalate"]
 
  # Used to enable the Kubernetes Monitor
 # Do not use this, as it is not supported at the moment

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -217,6 +217,10 @@ scriptPods:
     # @section -- Script pod values
     annotations: {}
 
+    # -- Use namespace-scoped Roles instead of ClusterRoles
+    # @section -- Script pod values
+    useNamespacedRoles: false
+
     # -- Specifies that the pod service account should be constrained to target namespaces
     # @section -- Script pod values
     # @default -- Uses a ClusterRoleBinding to allow the service account to run in any namespace
@@ -227,6 +231,11 @@ scriptPods:
     # @default -- `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]},{"nonResourceURLs":["*"],"verbs":["*"]}]`
     clusterRole:
       rules: []
+    
+    # -- if defined, overrides the default Role rules when using namespace-scoped roles
+    # @section -- Script pod values
+    # @default -- `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]`
+    roleRules: []
   
   # -- The tolerations to apply to script pods
   # @section -- Script pod values
@@ -372,6 +381,23 @@ persistence:
   # DO NOT USE THIS, it is not a supported configuration for customers and is only to be used by Octopus Developers
   # @ignored
   accessModes: ["ReadWriteMany"]
+
+# @section -- Auto-upgrader configuration
+autoUpgrader:
+  # -- Rules for managing the agent in its own namespace when using namespace-scoped roles
+  # @section -- Auto-upgrader configuration
+  selfNamespaceRoleRules:
+    - apiGroups: [ "*" ]
+      resources: [ "*" ]
+      verbs: [ "*" ]
+  # -- Rules for managing script pod roles in target namespaces when using namespace-scoped roles
+  # @section -- Auto-upgrader configuration
+  targetNamespaceRoleRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources: ["roles", "rolebindings"]
+      verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      resources: ["roles"]
 
  # Used to enable the Kubernetes Monitor
 # Do not use this, as it is not supported at the moment


### PR DESCRIPTION
This PR adds namespaced roles to the Kubernetes Agent helm chart.

Fixes: https://github.com/OctopusDeploy/Issues/issues/9553

## Changes

  - Added `scriptPods.serviceAccount.useNamespacedRoles` toggle (defaults to `false`)
  - Created templates for namespace-scoped Roles and RoleBindings
  - Auto-upgrading works within namespace boundaries when enabled
	  - Will not work if adding new namespaces

  Usage
```
scriptPods:
  serviceAccount:
    useNamespacedRoles: true
    targetNamespaces: ["namespace1", "namespace2"]
```

## Roles and RoleBindings Created (when `useNamespacedRoles="true"`)

**Script Pods:**
  - Creates a Role in each targetNamespace with permissions for script pod operations
  - Creates RoleBindings linking the script pod ServiceAccount to these Roles

**Auto-Upgrader:**
  - Creates a Role + RoleBinding in the agent's namespace for managing the main installation resources
  - Creates Roles + RoleBindings  in each targetNamespace for managing **script pod** Roles/RoleBindings

## Customisation
Override default permissions using:

```
scriptPods:
  serviceAccount:
    roleRules:  # Custom rules for script pods (default: wildcard)
      - apiGroups: [""]
        resources: ["pods", "secrets"]
        verbs: ["get", "list", "create"]

autoUpgrader:
  selfNamespaceRoleRules:  # Customise agent namespace permissions for the upgrader service account
      - apiGroups: [""]
        resources: ["pods", "secrets"]
        verbs: ["get", "list", "create"]
  targetNamespaceRoleRules: # Customise target namespace permissions for the upgrader service account
      - apiGroups: [""]
        resources: ["pods", "secrets"]
        verbs: ["get", "list", "create"]
```