### PR TITLE
fix: allow pvc for server-log-volume to use global storage class name

### DIFF
--- a/.changeset/solid-dryers-join.md
+++ b/.changeset/solid-dryers-join.md
@@ -1,0 +1,9 @@
+---
+"octopus-deploy": minor
+---
+
+Fix server-log-volume to use global storage class name
+
+Previously the server-log PVC omitted storageClassName when no explicit
+octopus.serverLogVolume.storageClassName was provided, ignoring the
+global override.

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
         env:
           {{- include "octopus.extraEnv" . | nindent 10 }}
           - name: ACCEPT_EULA
-            value: {{ template "octopus.acceptEulaStr" . }} 
+            value: {{ template "octopus.acceptEulaStr" . }}
           - name: OCTOPUS_SERVER_NODE_NAME
             valueFrom:
               fieldRef:
@@ -112,7 +112,7 @@ spec:
           - name: DISABLE_DIND
             value: !!str "Y"
         {{- end }}
-          - name: OCTOPUS_INSTALLED_VIA_HELM 
+          - name: OCTOPUS_INSTALLED_VIA_HELM
             value: "true"
         {{- if .Values.octopus.proxy.http }}
           - name: HTTP_PROXY
@@ -200,10 +200,14 @@ spec:
         name: server-log-volume
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        {{- if (eq "-" (.Values.octopus.serverLogVolume.storageClassName | toString)) }}
+        {{- $explicit := (.Values.octopus.serverLogVolume.storageClassName | toString) -}}
+        {{- $global  := ($.Values.global.storageClass | toString) -}}
+        {{- if eq $explicit "-" }}
         storageClassName: ""
-        {{- else if .Values.octopus.serverLogVolume.storageClassName }}
-        storageClassName: "{{ .Values.octopus.serverLogVolume.storageClassName }}"
+        {{- else if $explicit }}
+        storageClassName: {{ $explicit | quote }}
+        {{- else if $global }}
+        storageClassName: {{ $global | quote }}
         {{- end }}
         resources:
           requests:


### PR DESCRIPTION
### Server log pvc not using global.storageClass
Previously the server-log PVC omitted storageClassName when no explicit
octopus.serverLogVolume.storageClassName was provided, ignoring the
global override and leaving the claim unprovisioned on clusters without
a default StorageClass.

- StatefulSet: add fallback to $.Values.global.storageClass for
  server-log-volume.storageClassName when unset
- Preserve "-" sentinel (renders storageClassName: "")
- Use root $.Values and quote the value to avoid YAML issues

#### Before
```
helm template test . --set global.storageClass=cinder --set mssql.enabled="true"
...
  volumeClaimTemplates:
    - metadata:
        name: server-log-volume
      spec:
        accessModes: [ "ReadWriteOnce" ]
        resources:
          requests:
            storage: 200Mi
```

#### After
```
  volumeClaimTemplates:
    - metadata:
        name: server-log-volume
      spec:
        accessModes: [ "ReadWriteOnce" ]
        storageClassName: "cinder"
        resources:
          requests:
            storage: 200Mi
 ```

