### PR TITLE
Fix pod disruption budget

### DIFF
--- a/.changeset/cold-parks-begin.md
+++ b/.changeset/cold-parks-begin.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Fix issues with pod disruption budget

--- a/charts/kubernetes-agent/templates/script-pdb.yaml
+++ b/charts/kubernetes-agent/templates/script-pdb.yaml
@@ -5,7 +5,7 @@ metadata:
   name: script-pod-disruption-budget
   namespace: {{ .Release.Namespace }}
 spec:
-  maxUnavailable: 0
+  minAvailable: 8888
   selector:
     matchExpressions:
     - { key: octopus.com/scriptTicketId, operator: Exists }

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pdb_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pdb_test.yaml.snap
@@ -6,7 +6,7 @@ should match snapshot:
       name: script-pod-disruption-budget
       namespace: NAMESPACE
     spec:
-      maxUnavailable: 0
+      minAvailable: 8888
       selector:
         matchExpressions:
           - key: octopus.com/scriptTicketId

--- a/charts/kubernetes-agent/tests/script-pdb_test.yaml
+++ b/charts/kubernetes-agent/tests/script-pdb_test.yaml
@@ -28,8 +28,8 @@ tests:
           path: metadata.name
           value: script-pod-disruption-budget
       - equal:
-          path: spec.maxUnavailable
-          value: 0
+          path: spec.minAvailable
+          value: 8888
       - equal:
           path: spec.selector.matchExpressions[0].key
           value: octopus.com/scriptTicketId


### PR DESCRIPTION
[sc-121238]

Previously, we used `minUnavailable` set to `0` to ensure that no pods created by the agent would be removed.  
Unfortunately, since we never implemented a scale resource, this never worked correctly. This PR changes the minAvailable to a high integer value `8888`. This is arbitrary, but should be more than customers will use.  
This should ensure that the PDB fully applies to resources.

[For reference, this is the section of the disruption controller reconciliation that handles this](https://github.com/kubernetes/kubernetes/blob/b587977f7c8fc7ed4bdc5ed86afa9f1dd924667b/pkg/controller/disruption/disruption.go#L808-L848)