### PR TITLE
feat(kubernetes-agent): add optional hostNetwork for NFS server pod

### DIFF
--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -131,6 +131,7 @@ The Kubernetes agent is optionally installed alongside the Kubernetes agent, [re
 |-----|------|---------|-------------|
 | persistence.nfs.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to the NFS pod |
 | persistence.nfs.backingVolume.accessModes | list | `["ReadWriteOnce"]` | The access modes to use for the NFS Server's backing storage |
+| persistence.nfs.hostNetwork | bool | `false` | If true, the NFS server pod will use the host network. This can help bypass network policies that block NFS traffic from the CSI driver. |
 | persistence.nfs.backingVolume.storageClassName | string | `""` | The storage class name to use for the NFS Server's backing storage - if left as an empty string, an emptyDir will be used |
 | persistence.nfs.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/nfs-server","tag":"1.1.0"}` | The repository, pullPolicy & tag to use for the NFS server |
 | persistence.nfs.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the NFS pod & container |

--- a/charts/kubernetes-agent/templates/nfs-statefulset.yaml
+++ b/charts/kubernetes-agent/templates/nfs-statefulset.yaml
@@ -61,6 +61,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.persistence.nfs.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
   {{- if .Values.persistence.nfs.backingVolume.storageClassName }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -353,6 +353,10 @@ persistence:
       # @section -- Persistence
       accessModes: ["ReadWriteOnce"]
 
+    # -- If true, the NFS server pod will use the host network. This can help bypass network policies that block NFS traffic from the CSI driver.
+    # @section -- Persistence
+    hostNetwork: false
+
     # -- Additional metadata to add to the NFS pod & container
     # @section -- Persistence
     metadata:


### PR DESCRIPTION
## Summary

Add `persistence.nfs.hostNetwork` option to allow the NFS server pod to use the host network.

## Problem

When network policies are applied to a namespace, the NFS CSI driver cannot mount the NFS volume because:

1. The NFS CSI driver runs with `hostNetwork: true`, so traffic appears to come from node IPs
2. Network policies using `namespaceSelector` cannot match traffic from node IPs
3. This causes mount failures with "time out" or "Name or service not known" errors

## Solution

Add an optional `hostNetwork` setting for the NFS server pod. When enabled:
- The NFS server pod uses `hostNetwork: true`
- Sets `dnsPolicy: ClusterFirstWithHostNet` to ensure cluster DNS still works
- This allows the NFS server to bypass network policy enforcement

## Usage

```yaml
persistence:
  nfs:
    hostNetwork: true
```

## Changes

- `charts/kubernetes-agent/templates/nfs-statefulset.yaml`: Add conditional hostNetwork and dnsPolicy
- `charts/kubernetes-agent/values.yaml`: Add `persistence.nfs.hostNetwork` option (default: false)