### PR TITLE
Investigate Octopus Deploy helm chart compatibility with OpenShift

### DIFF
--- a/charts/octopus-deploy/charts/mssql/templates/statefulset.yaml
+++ b/charts/octopus-deploy/charts/mssql/templates/statefulset.yaml
@@ -35,6 +35,10 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
INVESTIGATION ONLY

trying to create an octopusdeploy chart that will work in openshift

related to https://github.com/OctopusDeploy/OctopusDeploy/pull/42058

currently - seems to be installed correctly to openshift using

```yaml
# helm upgrade octopus-deploy --install -n octopus-deploy --create-namespace -f values.yaml oci://ghcr.io/octopusdeploy/octopusdeploy-helm
octopus:
  acceptEula: Y
  image:
    repository: docker.packages.octopushq.com/octopusdeploy/octopusdeploy
    tag: 2026.2.4992-noamgal-yos-32-investigate-octopus-deploy-helm-chart-compatibility-with-linux

  licenseKeyBase64: <LICENSE_STRING>
  enableDockerInDocker: false

mssql:
  enabled: true
  podSecurityContext:
    fsGroup: 1000810000

  containerSecurityContext:
    runAsUser: 10001
    runAsGroup: 10001
```