### PR TITLE
chore: retrigger versioning workflow

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -117,5 +117,3 @@ jobs:
         git push --set-upstream origin changeset-release/main
       if: steps.changesets.outputs.hasChangesets == 'true'
 
-
-


### PR DESCRIPTION
## Summary
- Removes trailing blank lines from the versioning workflow file
- Triggers a fresh Version Charts workflow run with the updated `CHANGESETS_GITHUB_TOKEN`

## Context
The Version Charts workflow is failing because the previous token was revoked. The secret has been updated, but re-running the old job uses stale credentials. This PR triggers a fresh run on merge.