### PR TITLE
fix: remove unstable selector labels in mssql and octopus statefulsets

### DIFF
--- a/.changeset/open-hoops-scream.md
+++ b/.changeset/open-hoops-scream.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Fix unstable selector labels in mssql and octopus statefulsets

--- a/charts/octopus-deploy/charts/mssql/templates/_helpers.tpl
+++ b/charts/octopus-deploy/charts/mssql/templates/_helpers.tpl
@@ -28,7 +28,14 @@ If release name contains chart name it will be used as a full name.
 
 {{/* Selector Labels for mssql */}}
 {{- define "mssql.selectorLabels" -}}
-{{include "labels" . }}
+app.kubernetes.io/name: {{ include "octopus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: mssql
+{{- end -}}
+
+{{/* Pod Labels for mssql */}}
+{{- define "mssql.podLabels" -}}
+{{ include "labels" . }}
 app.kubernetes.io/component: mssql
 {{- end -}}
 

--- a/charts/octopus-deploy/charts/mssql/templates/statefulset.yaml
+++ b/charts/octopus-deploy/charts/mssql/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "mssql.selectorLabels" . | nindent 8 }}
+        {{- include "mssql.podLabels" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/octopus-deploy/templates/_helpers.tpl
+++ b/charts/octopus-deploy/templates/_helpers.tpl
@@ -32,7 +32,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Common Labels 
+Common Labels
 */}}
 {{- define "labels" -}}
 app.kubernetes.io/name: {{ include "octopus.name" . }}
@@ -43,7 +43,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{/* Selector Labels for octopus */}}
 {{- define "octopus.selectorLabels" -}}
-{{include "labels" . }}
+app.kubernetes.io/name: {{ include "octopus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: octopus-server
+{{- end -}}
+
+{{/* Pod Labels for octopus */}}
+{{- define "octopus.podLabels" -}}
+{{ include "labels" . }}
 app.kubernetes.io/component: octopus-server
 {{- end -}}
 

--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -22,7 +22,8 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    verbs: ["get", "delete"]
+    namespace: {{ .Release.Namespace }}
+    verbs: ["list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -61,9 +61,17 @@ spec:
     spec:
       serviceAccountName: {{ template "octopus.fullname" . }}-pre-upgrade
       restartPolicy: Never
+      {{- with .Values.octopus.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: pre-upgrade
           image: bitnami/kubectl:latest
+          {{- with .Values.octopus.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "octopus.fullname" . }}-pre-upgrade
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "octopus.fullname" . }}-pre-upgrade
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "octopus.fullname" . }}-pre-upgrade
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "octopus.fullname" . }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ template "octopus.fullname" . }}-pre-upgrade
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "octopus.fullname" . }}-pre-upgrade
+  labels:
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ template "octopus.fullname" . }}-pre-upgrade
+      restartPolicy: Never
+      containers:
+        - name: pre-upgrade
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              for sts in $(kubectl get statefulsets --namespace={{ .Release.Namespace }} -o jsonpath='{range .items[?(@.spec.selector.matchLabels.helm\.sh/chart)]}{.metadata.name}{"\n"}{end}'); do
+                echo "StatefulSet $sts has helm.sh/chart in selector matchLabels. Deleting with --cascade=orphan..."
+                kubectl delete statefulset "$sts" --namespace={{ .Release.Namespace }} --cascade=orphan
+              done
+  backoffLimit: 1

--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -22,7 +22,6 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    namespace: {{ .Release.Namespace }}
     verbs: ["list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hooks.enableSelectorLabelsFix }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -81,3 +82,4 @@ spec:
                 kubectl delete statefulset "$sts" --namespace={{ .Release.Namespace }} --cascade=orphan
               done
   backoffLimit: 1
+{{- end }}

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "octopus.selectorLabels" . | nindent 8 }}
+      {{- include "octopus.podLabels" . | nindent 8 }}
       {{- if .Values.octopus.pods.labels }}
       {{- toYaml .Values.octopus.pods.labels | nindent 8 }}
       {{- end }}

--- a/charts/octopus-deploy/tests/pre_upgrade_hook_test.yaml
+++ b/charts/octopus-deploy/tests/pre_upgrade_hook_test.yaml
@@ -1,0 +1,45 @@
+suite: pre-upgrade-hook
+templates:
+  - pre-upgrade-hook.yaml
+
+tests:
+  - it: pre-upgrade hook should render by default
+    values:
+      - ./values/required.yaml
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: pre-upgrade hook should not render when hooks.enableSelectorLabelsFix is false
+    values:
+      - ./values/required.yaml
+    set:
+      hooks.enableSelectorLabelsFix: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: pre-upgrade hook should render all four resources when hooks.enableSelectorLabelsFix is true
+    values:
+      - ./values/required.yaml
+    set:
+      hooks.enableSelectorLabelsFix: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - isKind:
+          of: Role
+        documentIndex: 1
+      - isKind:
+          of: RoleBinding
+        documentIndex: 2
+      - isKind:
+          of: Job
+        documentIndex: 3
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+        documentIndex: 3

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -224,6 +224,12 @@ mssql:
   tolerations: []
   affinity: {}
 
+hooks:
+  # Enables a pre-upgrade hook that deletes (with --cascade=orphan) any StatefulSet
+  # whose selector matchLabels still contain the legacy `helm.sh/chart` key, so that
+  # the StatefulSet can be re-created with the corrected selector.
+  enableSelectorLabelsFix: true
+
 global:
   # Set the default storageClass to be used for all persistent volume claims
   # this is overridden by the storageClassName in the individual volume claims if specified


### PR DESCRIPTION
## Fixed issue

`matchLabels` (which is immutable) included label `helm.sh/chart` had dynamic value. That was preventing chart from upgrading

```
kind: StatefulSet
metadata:
  name: octopus-deploy
spec:
  selector:
    matchLabels:
      app.kubernetes.io/component: octopus-server
      app.kubernetes.io/instance: octopus-deploy
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: octopus-deploy
      helm.sh/chart: octopusdeploy-helm-1.12.0 # this is dynamic value that causing issues during helm upgrade command
```