### PR TITLE
Simplify to-v3 migration

### DIFF
--- a/charts/kubernetes-agent/value-migrations-tests/to-v3-storageClassNameSet-expected.yaml
+++ b/charts/kubernetes-agent/value-migrations-tests/to-v3-storageClassNameSet-expected.yaml
@@ -1,4 +1,3 @@
 persistence:
-  storageClassName: "abc"
   nfs:
     enabled: false

--- a/charts/kubernetes-agent/value-migrations-tests/to-v3-volumeNameSet-expected.yaml
+++ b/charts/kubernetes-agent/value-migrations-tests/to-v3-volumeNameSet-expected.yaml
@@ -1,4 +1,3 @@
 persistence:
-  volumeName: "abc"
   nfs:
     enabled: false

--- a/charts/kubernetes-agent/value-migrations/to-v3.yaml
+++ b/charts/kubernetes-agent/value-migrations/to-v3.yaml
@@ -1,13 +1,8 @@
 {{- $isNfsEnabled := (not (or .persistence.storageClassName .persistence.volumeName)) -}}
 persistence:
+  {{/* This isn't strictly necessary, but we want to make it clear for NFS this is set */}}
   {{- if $isNfsEnabled }}
   accessModes: ["ReadWriteMany"]
-  {{- end}}
-  {{- if .persistence.storageClassName }}
-  storageClassName: "{{ .persistence.storageClassName }}"
-  {{- end}}  
-  {{- if .persistence.volumeName }}
-  volumeName: "{{ .persistence.volumeName }}"
   {{- end}}
   nfs:
     enabled: {{ $isNfsEnabled}}


### PR DESCRIPTION
We aren't making changes to the `persistence.storageClassName` or `persistence.volumeName`, so we don't need to include them in the migration

Fixes MD-1791