### PR TITLE
Always set accessModes in migration

### DIFF
--- a/charts/kubernetes-agent/migrations.md
+++ b/charts/kubernetes-agent/migrations.md
@@ -5,6 +5,33 @@ the chart may be upgraded:
 * Minor upgrade (\*.1.\*) - backwards compatible enhancement, upgrade can be executed without additional changes (new version adds new capabilities)
 * Major upgrade (1.\*.\*) - breaking-change (eg Values file structure changes), will require user-input to perform upgrade
 
+## Version 2 --> 3
+
+### Overview
+
+Version 3 of the Kubernetes agent changes the default storage from the in-cluster backed NFS server utilizing `ReadWriteMany`, to a single node `ReadWriteOnce` utilising the default storage class of the cluster.
+
+This decision was made due to customer feedback and general concerns about the performance, reliability and security of the NFS server.
+
+A side-effect of the change is that by default, the v3 agent no longer scales horizontally across nodes, but schedules the script pods on the same node as the agent/tentacle pod.
+
+The changes to the `values.yaml` file are the following additions:
+
+| Value name | Value | Comment |
+|--|--|--|
+| `persistence.nfs.enabled` | `false` | Indicates if the NFS pod should be used |
+| `persistence.accessModes` | `["ReadWriteOnce"]` | Sets the access mode used for the PVC |
+
+Kubernetes agents upgraded via Octopus Server will automatically continue to use the existing NFS-backed storage with no changes.
+
+To enable NFS-backed storage on new installations, set
+
+```yaml
+persistence.nfs.enabled: true
+persistence.accessModes: ["ReadWriteMany"]
+```
+as values during installation.
+
 ## Version 1 --> 2
 
 ### Overview
@@ -43,7 +70,7 @@ The following data items have been moved or renamed; data types, and content rem
 1. Fetch overriden values from your installed agent
 
 ```
-# Release and namespace can be found in Octopus Server, on the 'Connectivity' page of the Deployment Target being upgraded
+# Release and namespace can be found in Octopus Server, on the 'Connectivity' page of the Deployment Target or Worker being upgraded
 RELEASE=<Helm Release Name>
 NAMESPACE=<Namespace>
 
@@ -55,5 +82,5 @@ helm get values --namespace $NAMESPACE $RELEASE > overridden_values.yaml
 3. Upgrade your release to V2.0.0 of the helm-chart, applying your modified values
 
 ```
-helm upgrade --atomic --reset-then-reuse-values --namespace=$NAMESPACE $RELEASE -f overriden_values.yaml --version="2.*.*" "oci://docker.packages.octopushq.com/kubernetes-agent"
+helm upgrade --atomic --reset-then-reuse-values --namespace=$NAMESPACE $RELEASE -f overriden_values.yaml --version="2.*.*" "oci://registry-1.docker.io/octopusdeploy/kubernetes-agent"
 ```

--- a/charts/kubernetes-agent/value-migrations-tests/to-v3-storageClassNameSet-expected.yaml
+++ b/charts/kubernetes-agent/value-migrations-tests/to-v3-storageClassNameSet-expected.yaml
@@ -1,3 +1,4 @@
 persistence:
+  accessModes: ["ReadWriteMany"]
   nfs:
     enabled: false

--- a/charts/kubernetes-agent/value-migrations-tests/to-v3-volumeNameSet-expected.yaml
+++ b/charts/kubernetes-agent/value-migrations-tests/to-v3-volumeNameSet-expected.yaml
@@ -1,3 +1,4 @@
 persistence:
+  accessModes: ["ReadWriteMany"]
   nfs:
     enabled: false

--- a/charts/kubernetes-agent/value-migrations/to-v3.yaml
+++ b/charts/kubernetes-agent/value-migrations/to-v3.yaml
@@ -1,8 +1,6 @@
 {{- $isNfsEnabled := (not (or .persistence.storageClassName .persistence.volumeName)) -}}
 persistence:
-  {{/* This isn't strictly necessary, but we want to make it clear for NFS this is set */}}
-  {{- if $isNfsEnabled }}
+  {{/* To keep current behaviour, set the accessModes to ReadWriteMany */}}
   accessModes: ["ReadWriteMany"]
-  {{- end}}
   nfs:
     enabled: {{ $isNfsEnabled}}


### PR DESCRIPTION
When running the values file migration, we want to make sure the `ReadWriteMany` access mode is explicitly set to ensure existing behaviour is maintained

Also updates the migration documentation

