### PR TITLE
Fix link format in CHANGELOG for version 3.0.2

### DIFF
--- a/charts/kubernetes-agent/CHANGELOG.md
+++ b/charts/kubernetes-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- ec19f53: Forward merge changes from [2.38.3](#2.38.3)
+- ec19f53: Forward merge changes from [2.38.3](#2383)
 
 ## 3.0.1
 


### PR DESCRIPTION
# Description

I should have actually checked what the anchor format was...

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
