### PR TITLE
feat(octopus): add agent as optional subchart for default worker

### DIFF
--- a/charts/kubernetes-agent/templates/pre-install-tentacle-pod.yaml
+++ b/charts/kubernetes-agent/templates/pre-install-tentacle-pod.yaml
@@ -113,14 +113,14 @@ spec:
               name: {{ .Values.agent.bearerTokenSecretName | default (include "kubernetes-agent.preinstall.secrets.serverAuth" .) }}
               key: bearer-token
         {{- end }}
-        {{- if or .Values.agent.username .Values.agent.usernamePasswordSecretName }}
+        {{- if or .Values.global.username .Values.agent.username .Values.agent.usernamePasswordSecretName }}
         - name: "ServerUsername"
           valueFrom:
             secretKeyRef:
               name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.preinstall.secrets.serverAuth" .) }}
               key: username
         {{- end }}
-        {{- if or .Values.agent.password .Values.agent.usernamePasswordSecretName }}
+        {{- if or .Values.global.password .Values.agent.password .Values.agent.usernamePasswordSecretName }}
         - name: "ServerPassword"
           valueFrom:
             secretKeyRef:

--- a/charts/kubernetes-agent/templates/pre-install-tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/pre-install-tentacle-server-auth-secret.yaml
@@ -10,14 +10,14 @@ data:
 {{- if and (not .Values.agent.bearerTokenSecretName) (not .Values.agent.serverApiKeySecretName) (not .Values.agent.usernamePasswordSecretName) }}
 {{- with .Values.agent.bearerToken }}
   bearer-token: {{ . | b64enc }}
-{{- end }}  
+{{- end }}
 {{- with .Values.agent.serverApiKey }}
   api-key: {{ . | b64enc }}
 {{- end }}
-{{- with .Values.agent.username }}
+{{- with (coalesce .Values.global.username .Values.agent.username) }}
   username: {{ . | b64enc }}
 {{- end }}
-{{- with .Values.agent.password }}
+{{- with (coalesce .Values.global.password .Values.agent.password) }}
   password: {{ . | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -165,28 +165,28 @@ spec:
             {{- if or .Values.agent.bearerToken .Values.agent.bearerTokenSecretName  }}
             - name: "BearerToken"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.bearerTokenSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: bearer-token
             {{- end }}
-            {{- if or .Values.agent.username .Values.agent.usernamePasswordSecretName }}
+            {{- if or .Values.global.username .Values.agent.username .Values.agent.usernamePasswordSecretName }}
             - name: "ServerUsername"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: username
             {{- end }}
-            {{- if or .Values.agent.password .Values.agent.usernamePasswordSecretName }}
+            {{- if or .Values.global.password .Values.agent.password .Values.agent.usernamePasswordSecretName }}
             - name: "ServerPassword"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: password
             {{- end }}
             {{- if .Values.agent.certificate }}
             - name: "TentacleCertificateBase64"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ include "kubernetes-agent.secrets.certificate" . }}
                   key: certificate
             {{- end}}
@@ -202,14 +202,14 @@ spec:
             - name: "TentaclePollingProxyPort"
               value: {{ .Values.agent.pollingProxy.port | quote }}
             - name: "TentaclePollingProxyUsername"
-              value: {{ .Values.agent.pollingProxy.username | quote }}              
+              value: {{ .Values.agent.pollingProxy.username | quote }}
             {{- if .Values.agent.pollingProxy.password }}
             - name: "TentaclePollingProxyPassword"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
                   key: polling-proxy-password
-            {{- end }}            
+            {{- end }}
             {{- end }}
             {{- with .Values.agent.containers.tentacle.env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-server-auth-secret.yaml
@@ -8,14 +8,14 @@ data:
 {{- if and (not .Values.agent.bearerTokenSecretName) (not .Values.agent.serverApiKeySecretName) (not .Values.agent.usernamePasswordSecretName) }}
 {{- with .Values.agent.bearerToken }}
   bearer-token: {{ . | b64enc }}
-{{- end }}  
+{{- end }}
 {{- with .Values.agent.serverApiKey }}
   api-key: {{ . | b64enc }}
 {{- end }}
-{{- with .Values.agent.username }}
+{{- with (coalesce .Values.global.username .Values.agent.username) }}
   username: {{ . | b64enc }}
 {{- end }}
-{{- with .Values.agent.password }}
+{{- with (coalesce .Values.global.password .Values.agent.password) }}
   password: {{ . | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/octopus-deploy/Chart.yaml
+++ b/charts/octopus-deploy/Chart.yaml
@@ -15,3 +15,7 @@ dependencies:
   - name: mssql
     condition: mssql.enabled
     version: "0.0.1"
+  - name: kubernetes-agent
+    condition: kubernetes-agent.enabled
+    repository: "file://../kubernetes-agent"
+    version: "*"

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -1,3 +1,11 @@
+global:
+  # Set the default storageClass to be used for all persistent volume claims
+  # this is overridden by the storageClassName in the individual volume claims if specified
+  storageClass: ""
+
+  username: ""
+  password: ""
+
 octopus:
   # Must be set to "Y" or true to accept the EULA at https://octopus.com/legal/customer-agreement
   acceptEula: "N"
@@ -229,8 +237,3 @@ hooks:
   # whose selector matchLabels still contain the legacy `helm.sh/chart` key, so that
   # the StatefulSet can be re-created with the corrected selector.
   enableSelectorLabelsFix: true
-
-global:
-  # Set the default storageClass to be used for all persistent volume claims
-  # this is overridden by the storageClassName in the individual volume claims if specified
-  storageClass: ""


### PR DESCRIPTION
# Description

<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
