### PR TITLE
Update kubernetes-agent-tentacle to 9.1.3876

### DIFF
--- a/.changeset/every-olives-spend.md
+++ b/.changeset/every-olives-spend.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Merge imagePullSecrets from script pod template

--- a/.changeset/every-olives-spend.md
+++ b/.changeset/every-olives-spend.md
@@ -3,3 +3,7 @@
 ---
 
 Merge imagePullSecrets from script pod template
+
+Includes:
+
+- [Merge script pod template ImagePullSecrets](https://github.com/OctopusDeploy/OctopusTentacle/pull/1217)

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "2.38.3"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "9.1.3852"
+appVersion: "9.1.3876"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.38.3](https://img.shields.io/badge/Version-2.38.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.1.3852](https://img.shields.io/badge/AppVersion-9.1.3852-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.38.3](https://img.shields.io/badge/Version-2.38.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.1.3876](https://img.shields.io/badge/AppVersion-9.1.3876-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -57,7 +57,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.1.3852","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.1.3876","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
@@ -8,7 +8,7 @@ Should render all options when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -49,7 +49,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent
       namespace: NAMESPACE
@@ -80,7 +80,7 @@ should never have the containers key in the podSpec when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -115,7 +115,7 @@ should partially render successfully:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent
       namespace: NAMESPACE
@@ -140,7 +140,7 @@ should render a deployment when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-pod-template
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 9.1.3852
+            app.kubernetes.io/version: 9.1.3876
             helm.sh/chart: kubernetes-agent-2.38.3
         spec:
           affinity:
@@ -106,7 +106,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.1.3852
+              image: octopusdeploy/kubernetes-agent-tentacle:9.1.3876
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:
@@ -26,7 +26,7 @@ should match snapshot when volumeName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3852
+        app.kubernetes.io/version: 9.1.3876
         helm.sh/chart: kubernetes-agent-2.38.3
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -295,7 +295,7 @@ tests:
       asserts:
           - equal:
                 path: spec.template.spec.containers[0].image
-                value: "octopusdeploy/kubernetes-agent-tentacle:9.1.3852-bullseye-slim"
+                value: "octopusdeploy/kubernetes-agent-tentacle:9.1.3876-bullseye-slim"
 
     - it: "sets custom spec properly"
       set:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.1.3852"
+    tag: "9.1.3876"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.


### PR DESCRIPTION
# Description

Updates the `kubernetes-agent-tentacle` version to `9.1.3876`.

This contains the following change:

- https://github.com/OctopusDeploy/OctopusTentacle/pull/1217

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
