### PR TITLE
Upgrade kubernetes-agent dependency 'monitor-chart' to 0.28.0

### DIFF
--- a/.changeset/honest-brooms-slide.md
+++ b/.changeset/honest-brooms-slide.md
@@ -1,0 +1,9 @@
+---
+"kubernetes-agent": minor
+---
+
+Upgrade kubernetes-agent dependency 'monitor-chart' to 0.28.0
+
+Includes:
+- Docker image with non-root user by default
+- Strict security context by default

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.27.0
-digest: sha256:82fb431b1c8c6d95a6edbe12d5f2e66b671a1b414860178f221c19a46180fd4a
-generated: "2026-04-28T17:05:57.062303+03:00"
+  version: 0.28.0
+digest: sha256:a0efdf29352ebc62f989b0c642969ec9952307fa9c0856a0f4633ee92bcac71f
+generated: "2026-05-20T06:52:23.309356+03:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.27.0"
+    version: "0.28.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description

<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
