### PR TITLE
feat(kubernetes-agent): add nodeSelector for kubernetes-agent

### DIFF
--- a/.changeset/tender-cases-brush.md
+++ b/.changeset/tender-cases-brush.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Adding the ability to set nodeSelector for kubernetes-agent

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -62,6 +62,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |
 | agent.name | string | `""` | The name of the agent |
+| agent.nodeSelector | object | `{}` | The node selectors to apply to the agent pod |
 | agent.password | string | `""` | The password of the user used to authenticate with the target Octopus Server |
 | agent.pollingConnectionCount | int | `5` | The number of polling TCP connections to open with the target Octopus Server |
 | agent.pollingProxy | object | `{"host":"","password":"","port":80,"username":""}` | The host, port, username and password of the proxy server to use for polling connections |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -161,28 +161,28 @@ spec:
             {{- if or .Values.agent.bearerToken .Values.agent.bearerTokenSecretName  }}
             - name: "BearerToken"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.bearerTokenSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: bearer-token
             {{- end }}
             {{- if or .Values.agent.username .Values.agent.usernamePasswordSecretName }}
             - name: "ServerUsername"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: username
             {{- end }}
             {{- if or .Values.agent.password .Values.agent.usernamePasswordSecretName }}
             - name: "ServerPassword"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ .Values.agent.usernamePasswordSecretName | default (include "kubernetes-agent.secrets.serverAuth" .) }}
                   key: password
             {{- end }}
             {{- if .Values.agent.certificate }}
             - name: "TentacleCertificateBase64"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ include "kubernetes-agent.secrets.certificate" . }}
                   key: certificate
             {{- end}}
@@ -198,14 +198,14 @@ spec:
             - name: "TentaclePollingProxyPort"
               value: {{ .Values.agent.pollingProxy.port | quote }}
             - name: "TentaclePollingProxyUsername"
-              value: {{ .Values.agent.pollingProxy.username | quote }}              
+              value: {{ .Values.agent.pollingProxy.username | quote }}
             {{- if .Values.agent.pollingProxy.password }}
             - name: "TentaclePollingProxyPassword"
               valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                   name: {{ include "kubernetes-agent.secrets.serverAuth" . }}
                   key: polling-proxy-password
-            {{- end }}            
+            {{- end }}
             {{- end }}
             {{- with .Values.agent.containers.tentacle.env }}
             {{- toYaml . | nindent 12 }}
@@ -288,6 +288,10 @@ spec:
         - name: temp-dir
           emptyDir: {}
         {{- end }}
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.agent.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -157,6 +157,10 @@ agent:
   # @section -- Agent values
   tolerations: []
 
+  # -- The node selectors to apply to the agent pod
+  # @section -- Agent values
+  nodeSelector: {}
+
   # -- The affinities to apply to the agent pod
   # @section -- Agent values
   affinity:


### PR DESCRIPTION
# Description
Adding the ability to set nodeSelector for kubernetes-agent


<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
