### PR TITLE
add nodeSelector and affinity on pre-upgrade-hook (same as statefulset)

### DIFF
--- a/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
+++ b/charts/octopus-deploy/templates/pre-upgrade-hook.yaml
@@ -81,5 +81,13 @@ spec:
                 echo "StatefulSet $sts has helm.sh/chart in selector matchLabels. Deleting with --cascade=orphan..."
                 kubectl delete statefulset "$sts" --namespace={{ .Release.Namespace }} --cascade=orphan
               done
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1
 {{- end }}


### PR DESCRIPTION
# Description

I have a multi-architecture Kubernetes cluster with, among others, RISCV64 nodes. The job started on a RISCV64 node and not on my AMD64 node. This solves the problem and will inherit the same affinity and/or nodeSelector from the Statefulset.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.

Release Note: add nodeSelector and affinity on pre-upgrade-hook (same as statefulset)