### PR TITLE
fix: Use env vars for username and password when create secrets is false

### DIFF
--- a/.changeset/puny-streets-scream.md
+++ b/.changeset/puny-streets-scream.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": patch
+---
+
+Fix username and password environment variables when using external secrets

--- a/charts/octopus-deploy/templates/statefulset.yaml
+++ b/charts/octopus-deploy/templates/statefulset.yaml
@@ -86,14 +86,14 @@ spec:
               secretKeyRef:
                 name: {{printf "%s-%s" $.Release.Name "connectionstring"}}
                 key: secret
-          {{- if .Values.octopus.username }}
+          {{- if or .Values.octopus.username (not .Values.octopus.createSecrets) }}
           - name: ADMIN_USERNAME
             valueFrom:
               secretKeyRef:
                 name: {{printf "%s-%s" $.Release.Name "adminusername"}}
                 key: secret
           {{- end }}
-          {{- if .Values.octopus.password }}
+          {{- if or .Values.octopus.password (not .Values.octopus.createSecrets) }}
           - name: ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
# Background
Follow-up to commit ceeda72 (Make username and password optional)

This PR fixes an issue introduced in ceeda72 where external secret management was broken when `createSecrets: false`. The original PR successfully made username and password optional, but inadvertently prevented the use of external secrets by tying environment variable inclusion to values.yaml presence rather than considering the `createSecrets` flag.

When `createSecrets: false`, users expect to manage secrets externally (via tools like External Secrets Operator, Sealed Secrets, etc.), but the current logic excludes the `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables entirely if no username/password are provided in values.yaml, making external secrets unusable.

This PR restores external secret management capability while preserving the original intent of ceeda72.

# Changes Made

Modified the StatefulSet template to use the same pattern as the license key handling:

```yaml
# Before (broken for external secrets):
{{- if .Values.octopus.username }}
{{- if .Values.octopus.password }}

# After (consistent with license key pattern):
{{- if or .Values.octopus.username (not .Values.octopus.createSecrets) }}
{{- if or .Values.octopus.password (not .Values.octopus.createSecrets) }}
```

This ensures environment variables are included when:
- Values are provided in values.yaml, OR
- `createSecrets: false` (assuming external secret management)

# Testing
## Checking the manifest
Run `helm template test-auth .\charts\octopus-deploy -f test-auth.yaml --namespace test-auth` to verify behavior.

### Scenario 1: Username and password included in helm config with createSecrets: true
The manifest contains `ADMIN_USERNAME` and `ADMIN_PASSWORD` variables:
```yaml
          - name: ADMIN_USERNAME
            valueFrom:
              secretKeyRef:
                name: test-auth-adminusername
                key: secret
          - name: ADMIN_PASSWORD
            valueFrom:
              secretKeyRef:
                name: test-auth-adminpassword
                key: secret
```

### Scenario 2: Username and password excluded from helm config with createSecrets: true
The manifest does NOT contain the above variables (preserves original ceeda72 behavior).

### Scenario 3: Username and password excluded from helm config with createSecrets: false (NEW - Fixed by this PR)
The manifest DOES contain the environment variables, allowing external secrets to be used:
```yaml
          - name: ADMIN_USERNAME
            valueFrom:
              secretKeyRef:
                name: test-auth-adminusername
                key: secret
          - name: ADMIN_PASSWORD
            valueFrom:
              secretKeyRef:
                name: test-auth-adminpassword
                key: secret
```

### Scenario 4: Username and password included in helm config with createSecrets: false
The manifest contains the environment variables (edge case coverage).

## Test Configuration Files

### For Scenarios 1 & 4 (with credentials):
```yaml
octopus:
  acceptEula: "Y"
  username: "admin"
  password: "Password1!"
  email: "admin@example.com"
  licenseKeyBase64: "<Base 64 license>"
  createSecrets: true  # Change to false for Scenario 4

mssql:
  enabled: true
  image:
    repository: mcr.microsoft.com/mssql/server
    tag: 2019-latest
  acceptEula:
    value: "Y"
  SA_PASSWORD: "<Password for the DB>"
```

### For Scenarios 2 & 3 (without credentials):
```yaml
octopus:
  acceptEula: "Y"
  # username: "admin"    # Commented out
  # password: "Password1!"  # Commented out
  email: "admin@example.com"
  licenseKeyBase64: "<Base 64 license>"
  createSecrets: true  # Change to false for Scenario 3

mssql:
  enabled: true
  image:
    repository: mcr.microsoft.com/mssql/server
    tag: 2019-latest
  acceptEula:
    value: "Y"
  SA_PASSWORD: "<Password for the DB>"
```

## Verification Steps

1. Test all four scenarios above using `helm template`
2. Verify Scenario 2 maintains ceeda72's original behavior (no env vars when credentials omitted with createSecrets: true)
3. Verify Scenario 3 now works (env vars included when createSecrets: false, enabling external secrets)
4. Ensure backward compatibility for existing deployments

# Impact

- ✅ Preserves original ceeda72 functionality (optional credentials)
- ✅ Restores external secret management capability
- ✅ Maintains backward compatibility
- ✅ Follows existing pattern used by license key handling
- ✅ No breaking changes for existing users

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
