### PR TITLE
Add Calamari Image Volume configuration section

### DIFF
--- a/.changeset/kind-lizards-enjoy.md
+++ b/.changeset/kind-lizards-enjoy.md
@@ -5,7 +5,9 @@
 Add support for new Calamari image volume feature. By setting `scriptPods.calamariImageVolume.enabled` to `true`, the Calamari tooling is loaded into the script pod using the Kubernetes Image Volume as a read-only volume mount.
 
 > [!IMPORTANT]
-> This feature requires Kubernetes 1.35 or later as it requires the `ImageVolume` feature gate. If enabled on an older cluster, a warning will be written into the task log and the existing Octopus Server-distributed mechanism will be used.
+> This feature requires Kubernetes `1.35` or later as it requires the `ImageVolume` feature gate. If enabled on an older cluster, a warning will be written into the task log and the existing Octopus Server-distributed mechanism will be used.
+>
+> This feature also requires Octopus Server `2026.3.892` or later.
 
 There are two other configuration options for controlling the image being loaded:
 

--- a/.changeset/kind-lizards-enjoy.md
+++ b/.changeset/kind-lizards-enjoy.md
@@ -11,5 +11,5 @@ Add support for new Calamari image volume feature. By setting `scriptPods.calama
 
 There are two other configuration options for controlling the image being loaded:
 
-- `scriptPods.calamariImageVolume.image.repository` - Sets the repository where the Calamari image is loaded from. See the [documentation](https://octopus.com/docs) for more information about changing this.
+- `scriptPods.calamariImageVolume.image.repository` - Sets the repository where the Calamari image is loaded from. See the [documentation](https://oc.to/k8s-agent-calamari-image-volume) for more information about changing this.
 - `scriptPods.calamariImageVolume.image.pullPolicy` - Defines the pull policy for the Calamari image

--- a/.changeset/kind-lizards-enjoy.md
+++ b/.changeset/kind-lizards-enjoy.md
@@ -2,4 +2,12 @@
 "kubernetes-agent": minor
 ---
 
-Add support for new Calamari image volume feature
+Add support for new Calamari image volume feature. By setting `scriptPods.calamariImageVolume.enabled` to `true`, the Calamari tooling is loaded into the script pod using the Kubernetes Image Volume as a read-only volume mount.
+
+> [!IMPORTANT]
+> This feature requires Kubernetes 1.35 or later as it requires the `ImageVolume` feature gate. If enabled on an older cluster, a warning will be written into the task log and the existing Octopus Server-distributed mechanism will be used.
+
+There are two other configuration options for controlling the image being loaded:
+
+- `scriptPods.calamariImageVolume.image.repository` - Sets the repository where the Calamari image is loaded from. See the [documentation](https://octopus.com/docs) for more information about changing this.
+- `scriptPods.calamariImageVolume.image.pullPolicy` - Defines the pull policy for the Calamari image

--- a/.changeset/kind-lizards-enjoy.md
+++ b/.changeset/kind-lizards-enjoy.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Add support for new Calamari image volume feature

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "3.3.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "9.1.3876"
+appVersion: "9.2.4046"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "3.4.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "9.2.4046"
+appVersion: "9.2.4059"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -176,6 +176,8 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
+| scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. |
+| scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required. |
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.logging.disablePodEventsInTaskLog | bool | `false` | Disables script pod events being written to Octopus Server task log |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.1.3876](https://img.shields.io/badge/AppVersion-9.1.3876-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4046](https://img.shields.io/badge/AppVersion-9.2.4046-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -65,7 +65,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.1.3876","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4046","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.logLevel | string | `"Info"` | The log level of the agent. Logs are written to the pod logs as well as to file |
 | agent.machinePolicyName | string | `""` | The machine policy to register the agent with |
 | agent.metadata | object | `{"annotations":{},"labels":{}}` | Additional metadata to add to the agent pod & container |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -182,7 +182,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
-| scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.XXXX. |
+| scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.982. |
 | scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | See the [documentation](https://octopus.com/docs) for more information about changing the repository. |
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -183,7 +183,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
 | scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.982. |
-| scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | See the [documentation](https://octopus.com/docs) for more information about changing the repository. |
+| scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | See the [documentation](https://oc.to/k8s-agent-calamari-image-volume) for more information about changing the repository. |
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.logging.disablePodEventsInTaskLog | bool | `false` | Disables script pod events being written to Octopus Server task log |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -176,7 +176,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
-| scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. |
+| scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.XXXX. |
 | scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required. |
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4046](https://img.shields.io/badge/AppVersion-9.2.4046-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4059](https://img.shields.io/badge/AppVersion-9.2.4059-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -65,7 +65,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4046","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4059","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":30,"maxAgeSeconds":60,"periodSeconds":30,"timeoutSeconds":5}` | Liveness probe for polling Tentacles. Detects "pod Running but Tentacle process stuck" (deadlock, GC stall, frozen polling thread) by checking the freshness of a heartbeat file written by the agent. |
 | agent.livenessProbe.failureThreshold | int | `3` | Number of consecutive probe failures before Kubernetes restarts the pod. |
 | agent.livenessProbe.initialDelaySeconds | int | `30` | Seconds after the container starts before the first probe runs. |
@@ -183,7 +183,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 |-----|------|---------|-------------|
 | scriptPods.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}` | The affinities to apply to script pods |
 | scriptPods.calamariImageVolume.enabled | bool | `false` | Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.XXXX. |
-| scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required. |
+| scriptPods.calamariImageVolume.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy"}` | See the [documentation](https://octopus.com/docs) for more information about changing the repository. |
 | scriptPods.deploymentTarget.image | object | `{"pullPolicy":"","repository":"","tag":""}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a deployment target |
 | scriptPods.disruptionBudgetEnabled | bool | `true` | If true, the script pods will be created with a disruption budget to prevent them from being evicted |
 | scriptPods.logging.disablePodEventsInTaskLog | bool | `false` | Disables script pod events being written to Octopus Server task log |

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -127,6 +127,12 @@ spec:
               value: {{ .Values.agent.enableMetricsCapture | quote }}
             - name: "OCTOPUS__K8STENTACLE__PENDINGPODSSTUCKAFTERMINUTES"
               value: {{ .Values.scriptPods.pendingPodsTimeoutMinutes | quote }}
+            {{- if .Values.scriptPods.calamariImageVolume.enabled }}
+            - name: "OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY"
+              value: {{ .Values.scriptPods.calamariImageVolume.image.repository | quote }}
+            - name: "OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEPULLPOLICY"
+              value: {{ .Values.scriptPods.calamariImageVolume.image.pullPolicy | quote }}
+            {{- end }}
             {{- if .Values.imagePullSecrets }}
             - name: "OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES"
               value: {{ include "kubernetes-agent.imagePullSecretsCsv" . | quote }}

--- a/charts/kubernetes-agent/templates/tentacle-deployment.yaml
+++ b/charts/kubernetes-agent/templates/tentacle-deployment.yaml
@@ -128,6 +128,8 @@ spec:
             - name: "OCTOPUS__K8STENTACLE__PENDINGPODSSTUCKAFTERMINUTES"
               value: {{ .Values.scriptPods.pendingPodsTimeoutMinutes | quote }}
             {{- if .Values.scriptPods.calamariImageVolume.enabled }}
+            - name: "OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEENABLED"
+              value: "true"
             - name: "OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY"
               value: {{ .Values.scriptPods.calamariImageVolume.image.repository | quote }}
             - name: "OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEPULLPOLICY"

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
@@ -8,7 +8,7 @@ Should render all options when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -49,7 +49,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -80,7 +80,7 @@ should never have the containers key in the podSpec when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -115,7 +115,7 @@ should partially render successfully:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -140,7 +140,7 @@ should render a deployment when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
@@ -8,7 +8,7 @@ Should render all options when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -49,7 +49,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -80,7 +80,7 @@ should never have the containers key in the podSpec when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -115,7 +115,7 @@ should partially render successfully:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -140,7 +140,7 @@ should render a deployment when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -25,7 +25,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 9.1.3876
+            app.kubernetes.io/version: 9.2.4046
             helm.sh/chart: kubernetes-agent-3.3.0
         spec:
           affinity:
@@ -108,7 +108,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.1.3876
+              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4046
               imagePullPolicy: IfNotPresent
               name: octopus-agent-tentacle
               resources:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -25,7 +25,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 9.2.4046
+            app.kubernetes.io/version: 9.2.4059
             helm.sh/chart: kubernetes-agent-3.4.0
         spec:
           affinity:
@@ -108,7 +108,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4046
+              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4059
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is not set and nfs is disabled (defa
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -25,7 +25,7 @@ should match snapshot when storageClassName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -44,7 +44,7 @@ should match snapshot when storageClassName is set to "-" and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -64,7 +64,7 @@ should match snapshot when volumeName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-release-name-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is not set and nfs is disabled (defa
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -25,7 +25,7 @@ should match snapshot when storageClassName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -44,7 +44,7 @@ should match snapshot when storageClassName is set to "-" and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -64,7 +64,7 @@ should match snapshot when volumeName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-release-name-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.1.3876
+        app.kubernetes.io/version: 9.2.4046
         helm.sh/chart: kubernetes-agent-3.3.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4046
+        app.kubernetes.io/version: 9.2.4059
         helm.sh/chart: kubernetes-agent-3.4.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -561,6 +561,9 @@ tests:
           pullPolicy: "Always"
   asserts:
     - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEENABLED')].value
+        value: 'true'
+    - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY')].value
         value: 'index.docker.io/octopusdeploy'
     - equal:

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -549,7 +549,11 @@ tests:
         enabled: false
   asserts:
     - notExists:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEENABLED')].value
+    - notExists:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY')].value
+    - notExists:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEPULLPOLICY')].value
 
 - it: Sets the calamari image volume items when enabled
   set:

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -541,3 +541,28 @@ tests:
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__ACCESSMODESJSON')].value
         value: '["ReadWriteMany","ReadWriteOnce"]'
+
+- it: Does not set the calamari image volume items when not enabled
+  set:
+    scriptPods:
+      calamariImageVolume:
+        enabled: false
+  asserts:
+    - notExists:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY')].value
+
+- it: Sets the calamari image volume items when enabled
+  set:
+    scriptPods:
+      calamariImageVolume:
+        enabled: true
+        image:
+          repository: "index.docker.io/octopusdeploy"
+          pullPolicy: "Always"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEREPOSITORY')].value
+        value: 'index.docker.io/octopusdeploy'
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__CALAMARIIMAGEVOLUMEPULLPOLICY')].value
+        value: 'Always'

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -268,7 +268,7 @@ tests:
       asserts:
           - equal:
                 path: spec.template.spec.containers[0].image
-                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4046-bullseye-slim"
+                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4059-bullseye-slim"
 
     - it: "sets custom spec properly"
       set:

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -268,7 +268,7 @@ tests:
       asserts:
           - equal:
                 path: spec.template.spec.containers[0].image
-                value: "octopusdeploy/kubernetes-agent-tentacle:9.1.3876-bullseye-slim"
+                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4046-bullseye-slim"
 
     - it: "sets custom spec properly"
       set:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -376,7 +376,7 @@ scriptPods:
 
   calamariImageVolume:
     # -- If enabled, loads the [Calamari](https://github.com/OctopusDeploy/Calamari) tooling as a read-only image volume, rather than being pushed from Octopus Server.
-    # -- Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer.
+    # -- Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.XXXX.
     # @section -- Script pod values
     enabled: false
 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -400,7 +400,7 @@ scriptPods:
     enabled: false
 
     # -- The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required.
-    # -- See the [documentation](https://octopus.com/docs) for more information about changing the repository.
+    # -- See the [documentation](https://oc.to/k8s-agent-calamari-image-volume) for more information about changing the repository.
     # @section -- Script pod values
     image:
       repository: "octopusdeploy" 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.2.4046"
+    tag: "9.2.4059"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.
@@ -400,6 +400,7 @@ scriptPods:
     enabled: false
 
     # -- The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required.
+    # -- See the [documentation](https://octopus.com/docs) for more information about changing the repository.
     # @section -- Script pod values
     image:
       repository: "octopusdeploy" 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -395,7 +395,7 @@ scriptPods:
 
   calamariImageVolume:
     # -- If enabled, loads the [Calamari](https://github.com/OctopusDeploy/Calamari) tooling as a read-only image volume, rather than being pushed from Octopus Server.
-    # -- Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.XXXX.
+    # -- Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer. This also requires Octopus Server 2026.3.982.
     # @section -- Script pod values
     enabled: false
 

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -374,6 +374,18 @@ scriptPods:
   # @section -- Script pod values
   pendingPodsTimeoutMinutes: 60
 
+  calamariImageVolume:
+    # -- If enabled, loads the [Calamari](https://github.com/OctopusDeploy/Calamari) tooling as a read-only image volume, rather than being pushed from Octopus Server.
+    # -- Requires the ImageVolume Kubernetes feature gate, which is enabled by default on 1.35 and newer.
+    # @section -- Script pod values
+    enabled: false
+
+    # -- The repository and pullPolicy to use for the Calamari image volume. The repository should _not_ include the calamari image path, as this is dynamically set depending on the type of Calamari tooling required.
+    # @section -- Script pod values
+    image:
+      repository: "octopusdeploy" 
+      pullPolicy: IfNotPresent
+
 # @section -- Persistence
 persistence:
   # -- Sets the requested PVC access modes for both the agent pod and script pods.

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.1.3876"
+    tag: "9.2.4046"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.


### PR DESCRIPTION
# Description

Kubernetes 1.35 and newer supports loading docker images as readonly volumes. We can take advantage of this to load a docker image containing the specific Calamari version.

Adds a new configuration section `scriptPods.calamariImageVolume` which has the following nodes

- `enabled` - Indicates that the Calamari Image Volume feature is enabled.
- `image.repository` - Allows customising of the repository section of the resulting image. Example: `my-orgs-container-registry/octopusdeploy`. 
- `image.pullPolicy` - Sets the pull policy for the image

Related to MD-2016

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
