### PR TITLE
add annotations on service

### DIFF
--- a/charts/octopus-deploy/templates/service.yaml
+++ b/charts/octopus-deploy/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "octopus.fullname" . }}
   labels:
     {{- include "labels" . | nindent 4 }}
+  {{- with .Values.octopus.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.octopus.service.type }}
   selector:

--- a/charts/octopus-deploy/values.yaml
+++ b/charts/octopus-deploy/values.yaml
@@ -103,6 +103,7 @@ octopus:
 
   service:
     type: NodePort
+    annotations: {}
 
   ingress:
     enabled: false


### PR DESCRIPTION
# Description

Make it possible to add a dedicated ip for octopus with metallb

```yaml
octopus:
  service:
    annotations:
      # Request a specific IP from MetalLB's pool
      metallb.universe.tf/loadBalancerIPs: "192.168.8.53"
```

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
