### PR TITLE
ci(octopusdeploy-helm): publish chart to DockerHub

### DIFF
--- a/.github/workflows/octopus-publish-chart.yml
+++ b/.github/workflows/octopus-publish-chart.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Login to GitHub container registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u  ${{github.actor}} --password-stdin
 
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
       - name: Parse Chart config
         uses: pietrobolcato/action-read-yaml@1.1.0
         id: read_chart_yaml
@@ -84,6 +87,10 @@ jobs:
           path: '${{ github.workspace }}/octopusdeploy-helm-${{ steps.version.outputs.CHART_VERSION }}.tgz'
 
       # Only push the chart for real if it's a branch build OR it's the versioning PR
-      - name: Push Chart
+      - name: Push Chart to GHCR
         if: ${{ github.ref != 'refs/heads/main' || (github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'Version Charts')) }}
         run: helm push "octopusdeploy-helm-${{ steps.version.outputs.CHART_VERSION }}.tgz" oci://ghcr.io/octopusdeploy
+
+      - name: Push Chart to Docker Hub
+        if: ${{ github.ref != 'refs/heads/main' || (github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, 'Version Charts')) }}
+        run: helm push "octopusdeploy-helm-${{ steps.version.outputs.CHART_VERSION }}.tgz" oci://registry-1.docker.io/octopusdeploy


### PR DESCRIPTION
# Description
publish octopusdeploy-helm chart to DockerHub


<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
