### PR TITLE
Upgrade kubernetes-agent dependency 'monitor-chart' to 0.29.0

### DIFF
--- a/.changeset/sir-85-fix-cve-2026-33186.md
+++ b/.changeset/sir-85-fix-cve-2026-33186.md
@@ -1,0 +1,7 @@
+---
+"kubernetes-agent": minor
+---
+
+Upgrade kubernetes-agent-monitor to 0.29.0
+
+Fix CVE-2026-33186 -  gRPC-Go has an authorization bypass via missing leading slash in :path

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.28.0
-digest: sha256:a0efdf29352ebc62f989b0c642969ec9952307fa9c0856a0f4633ee92bcac71f
-generated: "2026-05-20T06:52:23.309356+03:00"
+  version: 0.29.0
+digest: sha256:520603f27e005566a18dac6edf4b63985eb0f5fd2097d3dc5089efa15c154395
+generated: "2026-06-10T06:08:20.583249+03:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.28.0"
+    version: "0.29.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description
Upgrade kubernetes-agent dependency 'monitor-chart' to 0.29.0 in order to fix `lobs-watcher` CVE-2026-33186
# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
