### PR TITLE
Upgrade kubernetes-agent dependency 'monitor-chart' to 0.29.0

### DIFF
--- a/.changeset/sir-85-fix-cve-2026-33186.md
+++ b/.changeset/sir-85-fix-cve-2026-33186.md
@@ -1,0 +1,7 @@
+---
+"kubernetes-agent": minor
+---
+
+Upgrade kubernetes-agent-monitor to 0.29.0
+
+Fix CVE-2026-33186 -  gRPC-Go has an authorization bypass via missing leading slash in :path


### PR DESCRIPTION
# Description
This chanage is required upgrade kubernetes-agent dependency 'monitor-chart' to 0.29.0 so tag 3.5.0 could be created

<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
