### PR TITLE
chore: update kubernetes-monitor-chart to version 0.30.0

### DIFF
--- a/.changeset/clean-yaks-look.md
+++ b/.changeset/clean-yaks-look.md
@@ -2,4 +2,14 @@
 "kubernetes-agent": minor
 ---
 
-Updating monitor chart to 0.30.0, includes security vulnerability fixes and rollout health status
+Upgrade kubernetes-agent-monitor to 0.30.0
+
+### Features
+
+* argo-rollout health status
+
+### Bug Fixes
+
+* fixed CVE-2026-29181 - update module go.opentelemetry.io/otel to v1.41.0 [security]
+* fixed CVE-2026-39882 - update module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp and go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp to v1.43.0 [security]
+* fixed CVE-2026-33814, CVE-2026-39821 - update module golang.org/x/net to v0.55.0 [security]

--- a/.changeset/clean-yaks-look.md
+++ b/.changeset/clean-yaks-look.md
@@ -10,6 +10,7 @@ Upgrade kubernetes-agent-monitor to 0.30.0
 
 ### Bug Fixes
 
-* fixed CVE-2026-29181 - update module go.opentelemetry.io/otel to v1.41.0 [security]
-* fixed CVE-2026-39882 - update module go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp and go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp to v1.43.0 [security]
-* fixed CVE-2026-33814, CVE-2026-39821 - update module golang.org/x/net to v0.55.0 [security]
+* CVE-2026-29181 - Allocation of Resources Without Limits or Throttling
+* CVE-2026-39882 - Memory Allocation with Excessive Size Value
+* CVE-2026-33814 - Loop with Unreachable Exit Condition ('Infinite Loop')
+* CVE-2026-39821 - Improper Validation of Unsafe Equivalence in Input

--- a/.changeset/clean-yaks-look.md
+++ b/.changeset/clean-yaks-look.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Updating monitor chart to 0.30.0, includes security vulnerability fixes and rollout health status

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.29.0
-digest: sha256:520603f27e005566a18dac6edf4b63985eb0f5fd2097d3dc5089efa15c154395
-generated: "2026-06-10T06:08:20.583249+03:00"
+  version: 0.30.0
+digest: sha256:3ec8531d416ef2e0e22b297a386e6395815f8b32151b83dc5cc16a4b15ca0444
+generated: "2026-06-18T17:00:16.671755+03:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.29.0"
+    version: "0.30.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
Upgrade the kubernetes-monitor-chart dependency to version 0.30.0 to address security vulnerabilities and improve rollout health status.

# Description

<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
