### PR TITLE
chore: upgrade kubernetes-agent-tentacle to version 9.2.4125

### DIFF
--- a/.changeset/brown-poems-rhyme.md
+++ b/.changeset/brown-poems-rhyme.md
@@ -1,0 +1,9 @@
+---
+"kubernetes-agent": major
+---
+
+Upgrade kubernetes-agent-tentacle to 9.2.4111
+
+- Update golang Docker tag to v1.26
+- CVE-2026-26171 (.NET XML: security bypass + DoS)
+- CVE-2026-33116 (.NET XML: DoS via infinite recursion in

--- a/.changeset/brown-poems-rhyme.md
+++ b/.changeset/brown-poems-rhyme.md
@@ -2,7 +2,7 @@
 "kubernetes-agent": major
 ---
 
-Upgrade kubernetes-agent-tentacle to 9.2.4111
+Upgrade kubernetes-agent-tentacle to 9.2.4125
 
 - Update golang Docker tag to v1.26
 - CVE-2026-26171 (.NET XML: security bypass + DoS)

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -57,7 +57,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4000","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4111","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":30,"maxAgeSeconds":60,"periodSeconds":30,"timeoutSeconds":5}` | Liveness probe for polling Tentacles. Detects "pod Running but Tentacle process stuck" (deadlock, GC stall, frozen polling thread) by checking the freshness of a heartbeat file written by the agent. |
 | agent.livenessProbe.failureThreshold | int | `3` | Number of consecutive probe failures before Kubernetes restarts the pod. |
 | agent.livenessProbe.initialDelaySeconds | int | `30` | Seconds after the container starts before the first probe runs. |

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -57,7 +57,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4111","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4125","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":30,"maxAgeSeconds":60,"periodSeconds":30,"timeoutSeconds":5}` | Liveness probe for polling Tentacles. Detects "pod Running but Tentacle process stuck" (deadlock, GC stall, frozen polling thread) by checking the freshness of a heartbeat file written by the agent. |
 | agent.livenessProbe.failureThreshold | int | `3` | Number of consecutive probe failures before Kubernetes restarts the pod. |
 | agent.livenessProbe.initialDelaySeconds | int | `30` | Seconds after the container starts before the first probe runs. |

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -106,7 +106,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4111
+              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4125
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -106,7 +106,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4000
+              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4111
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.2.4000"
+    tag: "9.2.4111"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.2.4111"
+    tag: "9.2.4125"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.


### PR DESCRIPTION
# Description

- Update golang Docker tag to v1.26
- Address CVE-2026-26171 (security bypass + DoS)
- Address CVE-2026-33116 (DoS via infinite recursion)

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
