### PR TITLE
fix changeset to bump minor, instead of major

### DIFF
--- a/.changeset/brown-poems-rhyme.md
+++ b/.changeset/brown-poems-rhyme.md
@@ -1,5 +1,5 @@
 ---
-"kubernetes-agent": major
+"kubernetes-agent": minor
 ---
 
 Upgrade kubernetes-agent-tentacle to 9.2.4125


### PR DESCRIPTION
# Description

i accidentally merged a changeset with `major` instead of `minor`. this is the fix

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
