### PR TITLE
Update kubernetes-agent-tentacle to 9.2.4125

### DIFF
--- a/.changeset/bump-tentacle-crypto-xml-fix.md
+++ b/.changeset/bump-tentacle-crypto-xml-fix.md
@@ -1,0 +1,9 @@
+---
+"kubernetes-agent": patch
+---
+
+Update kubernetes-agent-tentacle to 9.2.4125
+
+Includes:
+
+- [Pin System.Security.Cryptography.Xml to 8.0.3 (fixes CVE-2026-26171, CVE-2026-33116)](https://github.com/OctopusDeploy/OctopusTentacle/pull/1262)

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "3.6.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "9.2.4059"
+appVersion: "9.2.4125"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4059](https://img.shields.io/badge/AppVersion-9.2.4059-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4125](https://img.shields.io/badge/AppVersion-9.2.4125-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 
@@ -65,7 +65,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | agent.containers.watchdog.spec | object | `{}` | Additional container spec to apply to the watchdog container - does not override any other configuration |
 | agent.debug.disableAutoPodCleanup | bool | `false` | Disables automatic pod cleanup |
 | agent.enableMetricsCapture | bool | `true` | True if events should be scraped and added to the metrics config map |
-| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4059","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
+| agent.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/kubernetes-agent-tentacle","tag":"9.2.4125","tagSuffix":""}` | The repository, pullPolicy, tag & tagSuffix to use for the agent image |
 | agent.livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":30,"maxAgeSeconds":60,"periodSeconds":30,"timeoutSeconds":5}` | Liveness probe for polling Tentacles. Detects "pod Running but Tentacle process stuck" (deadlock, GC stall, frozen polling thread) by checking the freshness of a heartbeat file written by the agent. |
 | agent.livenessProbe.failureThreshold | int | `3` | Number of consecutive probe failures before Kubernetes restarts the pod. |
 | agent.livenessProbe.initialDelaySeconds | int | `30` | Seconds after the container starts before the first probe runs. |

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
@@ -8,7 +8,7 @@ Should render all options when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -49,7 +49,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -80,7 +80,7 @@ should never have the containers key in the podSpec when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -115,7 +115,7 @@ should partially render successfully:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -140,7 +140,7 @@ should render a deployment when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -25,7 +25,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 9.2.4059
+            app.kubernetes.io/version: 9.2.4125
             helm.sh/chart: kubernetes-agent-3.6.0
         spec:
           affinity:
@@ -108,7 +108,7 @@ should match snapshot:
                   value: '{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]},{"key":"kubernetes.io/arch","operator":"In","values":["arm64","amd64"]}]}]}}}'
                 - name: OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE
                   value: 10Gi
-              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4059
+              image: octopusdeploy/kubernetes-agent-tentacle:9.2.4125
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 exec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is not set and nfs is disabled (defa
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -25,7 +25,7 @@ should match snapshot when storageClassName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -44,7 +44,7 @@ should match snapshot when storageClassName is set to "-" and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-release-name-pvc
     spec:
@@ -64,7 +64,7 @@ should match snapshot when volumeName is set and nfs is disabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-release-name-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4059
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-3.6.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -268,7 +268,7 @@ tests:
       asserts:
           - equal:
                 path: spec.template.spec.containers[0].image
-                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4059-bullseye-slim"
+                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4125-bullseye-slim"
 
     - it: "sets custom spec properly"
       set:

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -120,7 +120,7 @@ agent:
   image:
     repository: octopusdeploy/kubernetes-agent-tentacle
     pullPolicy: IfNotPresent
-    tag: "9.2.4059"
+    tag: "9.2.4125"
     tagSuffix: ""
 
   # -- Credentials used during agent-upgrade tasks. To be populated if encountering rate-limiting failures.


### PR DESCRIPTION
## What

Bumps the `kubernetes-agent` chart's `appVersion` / `agent.image.tag` from **9.2.4059 → 9.2.4125**.

Follows the same shape as #588: `Chart.yaml` (appVersion), `values.yaml` (image tag), `README.md` (badges + values table), the `__snapshot__` test snapshots, and `tentacle-deployment_test.yaml`, plus a changeset. The chart `version` is intentionally left for the Version Charts automation to bump from the changeset.

## Why

Chart **3.6.0** ships `appVersion: 9.2.4059` — a `kubernetes-agent-tentacle` image built **2026-06-05**, which predates the security fix. That image bundles the vulnerable `System.Security.Cryptography.Xml` **8.0.2**:

- **CVE-2026-26171** — .NET XML security bypass + DoS (HIGH)
- **CVE-2026-33116** — .NET XML DoS via infinite recursion (HIGH)

The fix ([OctopusDeploy/OctopusTentacle#1262](https://github.com/OctopusDeploy/OctopusTentacle/pull/1262), pinning `System.Security.Cryptography.Xml` to 8.0.3) merged on 2026-06-19, but the chart never advanced its `appVersion`, so customers installing via Helm still get the vulnerable image.

`9.2.4125` (built 2026-06-21) is the current image and is **verified** to bundle `System.Security.Cryptography.Xml 8.0.3` with **zero** remaining Xml CVEs (Trivy).

## Verification

\`\`\`
trivy image octopusdeploy/kubernetes-agent-tentacle:9.2.4125 | grep Cryptography.Xml
# -> System.Security.Cryptography.Xml 8.0.3, no CVEs
\`\`\`

After this releases, \`helm show chart oci://.../kubernetes-agent --version <new>\` will report the bumped \`appVersion\`, and a scan of the deployed image will be clean.