### PR TITLE
chore(k8s-monitor): version 0.31.0 with custom permissions support

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -92,7 +92,7 @@ jobs:
           chart_version="${{ steps.read_chart_yaml.outputs.version }}"
           pre_release=""
 
-          if [ "${{steps.branch_names.outputs.branch_name}}" != "main" ] && [[ "${{steps.branch_names.outputs.branch_name}}" != "release/kubernetes-agent/v"* ]]
+          if [ "${{github.ref_name}}" != "main" ] && [[ "${{github.ref_name}}" != "release/kubernetes-agent/v"* ]]
           then
               # underscores in branches make for illegal version-string, replace with "-"
               cleansed_branch=`echo ${{steps.branch_names.outputs.branch_name}} | sed s/_/-/g`

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.30.0
-digest: sha256:3ec8531d416ef2e0e22b297a386e6395815f8b32151b83dc5cc16a4b15ca0444
-generated: "2026-06-18T17:00:16.671755+03:00"
+  version: 0.31.0
+digest: sha256:6680ecd67d4905b78833f90f6db6f932dbef9f765efbdb3b7d8e56f95ea75ca9
+generated: "2026-06-22T19:34:09.293175+03:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.30.0"
+    version: "0.31.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description
New version of k8s monitor - 0.31.0.
**Version includes:**
- new value `monitor.rules` - list of permitted resources for monitoring
<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
