### PR TITLE
Fix Chart.yaml app version and add new test

### DIFF
--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -55,12 +55,11 @@ jobs:
         id: read_values_yaml
         with:
           config: ${{ github.workspace }}/charts/kubernetes-agent/values.yaml
-          key-path-pattern: ^agent\.image\.
       
       - name: Enforce appVersion and tag match
         run: |
           chart_appVersion="${{ steps.read_chart_yaml.outputs['appVersion'] }}"
-          values_tag="${{ steps.read_values_yaml.outputs['tag'] }}"
+          values_tag="${{ steps.read_values_yaml.outputs['agent.image.tag'] }}"
 
           echo "Chart.yaml .appVersion: $chart_appVersion"
           echo "values.yaml .agent.image.tag: $values_tag"

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -44,6 +44,31 @@ jobs:
           helm plugin install https://github.com/helm-unittest/helm-unittest.git
           helm unittest charts/kubernetes-agent
 
+      - name: Parse Chart config
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: read_chart_yaml
+        with:
+          config: ${{ github.workspace }}/charts/kubernetes-agent/Chart.yaml
+      
+      - name: Parse values.yaml
+        uses: pietrobolcato/action-read-yaml@1.1.0
+        id: read_values_yaml
+        with:
+          config: ${{ github.workspace }}/charts/kubernetes-agent/values.yaml
+      
+      - name: Enforce appVersion and tag match
+        run: |
+          chart_appVersion="${{ steps.read_chart_yaml.outputs.appVersion }}"
+          values_tag="${{ steps.read_values_yaml.outputs.agent.image.tag}}"
+
+          echo "Chart.yaml .appVersion: $chart_appVersion"
+          echo "values.yaml .agent.image.tag: $values_tag"
+
+          if [[ $chart_appVersion != $values_tag ]]; then
+            echo "The Chart.yaml .appVersion and values.yaml .agent.image.tag are not the same. These must match."
+            exit 1
+          fi
+
   check-readme:
     needs: paths_filter
     if: needs.paths_filter.outputs.result == 'true'

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -55,11 +55,12 @@ jobs:
         id: read_values_yaml
         with:
           config: ${{ github.workspace }}/charts/kubernetes-agent/values.yaml
+          key-path-pattern: ^agent\.image\.
       
       - name: Enforce appVersion and tag match
         run: |
           chart_appVersion="${{ steps.read_chart_yaml.outputs.appVersion }}"
-          values_tag="${{ steps.read_values_yaml.outputs.agent.image.tag}}"
+          values_tag="${{ steps.read_values_yaml.outputs.tag }}"
 
           echo "Chart.yaml .appVersion: $chart_appVersion"
           echo "values.yaml .agent.image.tag: $values_tag"

--- a/.github/workflows/kubernetes-agent-publish-chart.yaml
+++ b/.github/workflows/kubernetes-agent-publish-chart.yaml
@@ -59,8 +59,8 @@ jobs:
       
       - name: Enforce appVersion and tag match
         run: |
-          chart_appVersion="${{ steps.read_chart_yaml.outputs.appVersion }}"
-          values_tag="${{ steps.read_values_yaml.outputs.tag }}"
+          chart_appVersion="${{ steps.read_chart_yaml.outputs['appVersion'] }}"
+          values_tag="${{ steps.read_values_yaml.outputs['tag'] }}"
 
           echo "Chart.yaml .appVersion: $chart_appVersion"
           echo "values.yaml .agent.image.tag: $values_tag"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -17,4 +17,4 @@ dependencies:
 type: application
 version: "2.45.0"
 # This version number should be the same as the agent.image.tag value as this is the primary application version
-appVersion: "9.2.4000"
+appVersion: "9.2.4125"

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -1,6 +1,6 @@
 ## Kubernetes agent
 
-![Version: 2.45.0](https://img.shields.io/badge/Version-2.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4000](https://img.shields.io/badge/AppVersion-9.2.4000-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
+![Version: 2.45.0](https://img.shields.io/badge/Version-2.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.2.4125](https://img.shields.io/badge/AppVersion-9.2.4125-informational?style=flat-square) ![Octopus Deploy Version: 2024.2.6580+](https://img.shields.io/badge/Octopus_Deploy-2024.2.6580%2B-2F93E0?style=flat-square&logo=octopusdeploy&logoColor=%232F93E0&logoSize=auto)
 
 The Kubernetes agent is the recommended way to deploy to Kubernetes clusters using [Octopus Deploy](https://octopus.com).
 

--- a/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/auto-upgrader-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-auto-upgrader
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/pod-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-scripts
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/script-pod-template_test.yaml.snap
@@ -8,7 +8,7 @@ Should render all options when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -49,7 +49,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -80,7 +80,7 @@ should never have the containers key in the podSpec when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE
@@ -115,7 +115,7 @@ should partially render successfully:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent
       namespace: NAMESPACE
@@ -140,7 +140,7 @@ should render a deployment when crdDisabled is true:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-pod-template
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-deployment_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE
@@ -23,7 +23,7 @@ should match snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: octopus-agent
-            app.kubernetes.io/version: 9.2.4000
+            app.kubernetes.io/version: 9.2.4125
             helm.sh/chart: kubernetes-agent-2.45.0
         spec:
           affinity:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-pvc_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot when storageClassName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:
@@ -26,7 +26,7 @@ should match snapshot when volumeName is set:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-RELEASE-NAME-pvc
     spec:

--- a/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
+++ b/charts/kubernetes-agent/tests/__snapshot__/tentacle-serviceaccount_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: octopus-agent
-        app.kubernetes.io/version: 9.2.4000
+        app.kubernetes.io/version: 9.2.4125
         helm.sh/chart: kubernetes-agent-2.45.0
       name: octopus-agent-tentacle
       namespace: NAMESPACE

--- a/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment_test.yaml
@@ -295,7 +295,7 @@ tests:
       asserts:
           - equal:
                 path: spec.template.spec.containers[0].image
-                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4000-bullseye-slim"
+                value: "octopusdeploy/kubernetes-agent-tentacle:9.2.4125-bullseye-slim"
 
     - it: "sets custom spec properly"
       set:


### PR DESCRIPTION
# Description

In #627 we updated the `.agent.image.tag` value in `values.yaml`, but didn't update the corresponding `.appVersion` value in `Chart.yaml`.

This is needed as we have tests in Octopus Deploy that assert on this.

I have fixed this and added a new check during the GHA test run to verify these are the same value

This also fixes up all the test snapshots and the readme

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
