### PR TITLE
Update Octopus Server to 2026.2

### DIFF
--- a/.changeset/common-lies-rest.md
+++ b/.changeset/common-lies-rest.md
@@ -1,0 +1,5 @@
+---
+"octopus-deploy": minor
+---
+
+Update Octopus Server to 2026.2

--- a/charts/octopus-deploy/Chart.yaml
+++ b/charts/octopus-deploy/Chart.yaml
@@ -10,7 +10,7 @@ version: 1.14.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026.1"
+appVersion: "2026.2"
 dependencies:
   - name: mssql
     condition: mssql.enabled


### PR DESCRIPTION
# Description

Octopus Server 2026.2 has been released to GA, so update the default version in the Helm chart

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
