### PR TITLE
Update worker script pod image tag to ubuntu.24.04

### DIFF
--- a/.changeset/quick-points-create.md
+++ b/.changeset/quick-points-create.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Update default worker script pod image to `ubuntu.24.04`

--- a/charts/kubernetes-agent/README.md
+++ b/charts/kubernetes-agent/README.md
@@ -195,7 +195,7 @@ The Kubernetes monitor is optionally installed alongside the Kubernetes agent, [
 | scriptPods.serviceAccount.targetNamespaces | list | Uses a ClusterRoleBinding to allow the service account to run in any namespace | Specifies that the pod service account should be constrained to target namespaces |
 | scriptPods.serviceAccount.useNamespacedRoles | bool | `false` | Use namespace-scoped Roles instead of ClusterRoles |
 | scriptPods.tolerations | list | `[]` | The tolerations to apply to script pods |
-| scriptPods.worker.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/worker-tools","tag":"ubuntu.22.04"}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a worker |
+| scriptPods.worker.image | object | `{"pullPolicy":"IfNotPresent","repository":"octopusdeploy/worker-tools","tag":"ubuntu.24.04"}` | The repository, pullPolicy & tag to use for the script pod image when the agent is a worker |
 | scriptPods.workerRoleRules | list | `[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]` | If set to a non-empty list, completely replaces the default Role rules for the script pod worker role (only created when `agent.worker.enabled=true`). Note: `[]` (empty list) means "use defaults", not "no rules". |
 
 ### Other Values

--- a/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
+++ b/charts/kubernetes-agent/tests/tentacle-deployment-container-env-vars_test.yaml
@@ -455,7 +455,7 @@ tests:
         value: "octopusdeploy/worker-tools"
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODIMAGETAG')].value
-        value: "ubuntu.22.04"
+        value: "ubuntu.24.04"
     - equal:
         path: spec.template.spec.containers[0].env[?(@.name == 'OCTOPUS__K8STENTACLE__SCRIPTPODPULLPOLICY')].value
         value: "IfNotPresent"

--- a/charts/kubernetes-agent/values.yaml
+++ b/charts/kubernetes-agent/values.yaml
@@ -347,7 +347,7 @@ scriptPods:
     image:
       repository: octopusdeploy/worker-tools
       pullPolicy: IfNotPresent
-      tag: "ubuntu.22.04"
+      tag: "ubuntu.24.04"
 
   logging:
     # -- Disables script pod events being written to Octopus Server task log


### PR DESCRIPTION
# Description

With the release of the `ubuntu.24.04` worker tools image, we now publish a `linux/arm64` platform version of this, meaning Kubernetes workers running on ARM64 nodes will work correctly

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
