### PR TITLE
Bump monitor version v2

### DIFF
--- a/.changeset/lucky-pugs-shout.md
+++ b/.changeset/lucky-pugs-shout.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": minor
+---
+
+Bumped Kubernetes Monitor version to 0.33.0

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.32.0
-digest: sha256:0451db31a35cc266a23a46aa404ac52249b2e766019ffd0d579e390e361ebd5c
-generated: "2026-07-28T10:47:40.013793+10:00"
+  version: 0.33.0
+digest: sha256:72631b99494cc9245506ae78889b415b271d54793368ce9c622749b787b39212
+generated: "2026-08-03T02:55:37.78471309Z"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.32.0"
+    version: "0.33.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description
Bumps the Kubernetes monitor version to 0.33.0 to pick up https://github.com/OctopusDeploy/lobster-watcher/pull/324

Fixes https://github.com/OctopusDeploy/helm-charts/issues/665


# Pre-requisites
- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.