### PR TITLE
Update Kubernetes monitor to 0.36. This changes the gRPC connection to use compression by default.

### DIFF
--- a/.changeset/clear-mugs-remain.md
+++ b/.changeset/clear-mugs-remain.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Breaking change: Pickup Kubernetes monitor 0.36 for compression changes

--- a/.changeset/clear-mugs-remain.md
+++ b/.changeset/clear-mugs-remain.md
@@ -2,4 +2,6 @@
 "kubernetes-agent": patch
 ---
 
-Breaking change: Pickup Kubernetes monitor 0.36 for compression changes
+Update Kubernetes monitor to 0.36. This changes the gRPC connection to use compression by default.
+
+Note: If you are using a custom proxy between the monitor and Octopus Server, you may experience issues. Please contact support@octopus.com

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.34.0
-digest: sha256:89746ca8b7f3aff2ae1f2f41608e7f32edaae8d43fab1f0067d3900f0ad86d5b
-generated: "2026-08-04T13:49:29.858663+10:00"
+  version: 0.36.0
+digest: sha256:bc61f5d51f2c8d381bdeef9ab7724b70984926ab08192275421f0609e3b35546
+generated: "2026-08-07T12:52:25.785536+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.35.0"
+    version: "0.36.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.34.0"
+    version: "0.35.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Summary

Update Kubernetes monitor to 0.36. This changes the gRPC connection to use compression by default.
 
**Note: If you are using a custom proxy between the monitor and Octopus Server, you may experience issues. Please contact support@octopus.com**

# Details
Bumps the `kubernetes-monitor-chart` subchart dependency from 0.34.0 to 0.36.0 to pick up [lobster-watcher#329](https://github.com/OctopusDeploy/lobster-watcher/pull/329) and https://github.com/OctopusDeploy/lobster-watcher/pull/335, which fixes updates being dropped when a cluster's resource snapshot exceeds the max gRPC message size.

The fix adds gRPC compression (on by default) which may cause issues in certain environments with proxies. Compression can be disabled by setting the `kubernetesMonitor.disableGrpcCompression` value to "false".

Fixes https://github.com/OctopusDeploy/helm-charts/issues/674

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.