### PR TITLE
Change patch to minor

### DIFF
--- a/.changeset/clear-mugs-remain.md
+++ b/.changeset/clear-mugs-remain.md
@@ -1,5 +1,5 @@
 ---
-"kubernetes-agent": patch
+"kubernetes-agent": feature
 ---
 
 Update Kubernetes monitor to 0.36. This changes the gRPC connection to use compression by default.

--- a/.changeset/clear-mugs-remain.md
+++ b/.changeset/clear-mugs-remain.md
@@ -1,5 +1,5 @@
 ---
-"kubernetes-agent": feature
+"kubernetes-agent": minor
 ---
 
 Update Kubernetes monitor to 0.36. This changes the gRPC connection to use compression by default.


### PR DESCRIPTION
# Description

https://github.com/OctopusDeploy/helm-charts/pull/673 introduced a patch bump, but we want to bump minor because we're enabling compression by default.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
