### PR TITLE
Update Kubernetes monitor to 0.37

### DIFF
--- a/.changeset/lucky-moments-pull.md
+++ b/.changeset/lucky-moments-pull.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Update Kubernetes monitor to 0.37.

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.36.0
-digest: sha256:bc61f5d51f2c8d381bdeef9ab7724b70984926ab08192275421f0609e3b35546
-generated: "2026-08-07T12:52:25.785536+10:00"
+  version: 0.37.0
+digest: sha256:396da36432cd1269c8f3a99d3566f2f30f65f7331e5a78f19a1665f4878e49e1
+generated: "2026-08-18T11:58:30.986997+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.36.0"
+    version: "0.37.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description

Update Kubernetes monitor to 0.37. 

The monitor now reports `Orphaned` sync status ([feat: report orphan status](https://github.com/OctopusDeploy/lobster-watcher/pull/334#top)). This is a backwards compatible change.


# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
