### PR TITLE
Fix possible fix(deps): 10 vulnerable dependencies in go.mod

### DIFF
--- a/charts/kubernetes-agent/crd-gen/go.mod
+++ b/charts/kubernetes-agent/crd-gen/go.mod
@@ -57,23 +57,23 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.33.0 // indirect
 	go.opentelemetry.io/otel/metric v1.33.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.33.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
-	google.golang.org/grpc v1.68.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect


### PR DESCRIPTION
This changes `charts/kubernetes-agent/crd-gen/go.mod` to address something a scan flagged. It is around line 1.

The code imports google.golang.org/grpc at version v1.68.1, which is vulnerable to CVE-2026-33186. This bug allows an attacker to bypass path‑based authorization by sending HTTP/2 frames with a malformed ':path' header (missing the leading slash). Authorization interceptors see the non‑canonical path, causing deny rules that expect a leading '/' to be ignored, potentially granting access to privileged RPCs. The vulnerability is critical because it can be exploited by any client capable of raw HTTP/2 communication and may lead to full service compromise. The recommended mitigation is to upgrade the gRPC library to version 1.79.3 or later, where the server rejects such malformed paths with a `codes.Unimplemented` error.

Updated vulnerable indirect dependencies to their fixed versions per advisory.

For reference: rule `CVE-2026-33186`. Rated critical.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
