### PR TITLE
Fix possible fix(deps): 21 vulnerable dependencies in go.mod

### DIFF
--- a/charts/kubernetes-agent/value-migrations-tests/go.mod
+++ b/charts/kubernetes-agent/value-migrations-tests/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/containerd v1.7.29 // indirect
+	github.com/containerd/containerd v1.7.33 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
@@ -89,16 +89,16 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
-	google.golang.org/grpc v1.72.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
@@ -115,7 +115,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/kubectl v0.34.2 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
+	oras.land/oras-go/v2 v2.6.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect


### PR DESCRIPTION
Proposing a fix for something flagged in `charts/kubernetes-agent/value-migrations-tests/go.mod`. It is around line 1.

The gRPC-Go server before v1.79.3 does not validate the HTTP/2 :path pseudo-header, accepting malformed paths that omit the mandatory leading slash (e.g., `Service/Method` instead of `/Service/Method`). Authorization interceptors evaluate the raw, non‑canonical path string, causing deny rules that expect canonical paths to miss the request, allowing it to bypass policy if a fallback allow rule exists. An attacker can send raw HTTP/2 frames with such malformed :path headers directly to the server, leading to a critical authorization bypass. Upgrading to google.golang.org/grpc v1.79.3 (or using a validating interceptor) ensures any request with a non‑canonical :path is rejected early with `codes.Unimplemented`, preventing the bypass.

Upgrade vulnerable indirect dependencies to patched versions, resolving multiple CVE advisories.

For reference: rule `CVE-2026-33186`. Rated critical.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
