### PR TITLE
bump k8s monitor to v0.39.0

### DIFF
--- a/.changeset/nasty-women-clean.md
+++ b/.changeset/nasty-women-clean.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Update monitor chart to v0.38.0

--- a/.changeset/nasty-women-clean.md
+++ b/.changeset/nasty-women-clean.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": patch
 ---
 
-Update monitor chart to v0.38.0
+Update monitor chart to v0.39.0

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.38.0
-digest: sha256:b0e908446f8b6c3a03aa4da2cd5020b5d477b0cb7033312a51d297face1d9294
-generated: "2026-08-27T17:23:22.590969+10:00"
+  version: 0.39.0
+digest: sha256:a878241cbffc1d6913ecf70b6e6ab3476b69ebf1869e9e001dd3f4717b313146
+generated: "2026-08-28T16:39:25.884229+10:00"

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.37.0
-digest: sha256:396da36432cd1269c8f3a99d3566f2f30f65f7331e5a78f19a1665f4878e49e1
-generated: "2026-08-18T11:58:30.986997+10:00"
+  version: 0.38.0
+digest: sha256:b0e908446f8b6c3a03aa4da2cd5020b5d477b0cb7033312a51d297face1d9294
+generated: "2026-08-27T17:23:22.590969+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.37.0"
+    version: "0.38.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.38.0"
+    version: "0.39.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description
This PR is the same as #725, but for the v2 agent. Originally, it was to bump to v0.38.0, but we found a bug to fix so I'm skipping 0.38.0 to go straight to 0.39.0