### PR TITLE
Bump Kubernetes Monitor chart to get rehydration fix

### DIFF
--- a/.changeset/swift-lions-work.md
+++ b/.changeset/swift-lions-work.md
@@ -1,0 +1,5 @@
+---
+"kubernetes-agent": patch
+---
+
+Bump Kubernetes Monitor chart to get rehydration fix

--- a/.changeset/swift-lions-work.md
+++ b/.changeset/swift-lions-work.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": patch
 ---
 
-Bump Kubernetes Monitor chart to 0.40.0
+Bump Kubernetes Monitor chart to 0.40.0. This fixes a bug where child resources deleted while the monitor is offline linger in live status until the next periodic snapshot. See https://github.com/OctopusDeploy/helm-charts/issues/731 for more details.

--- a/.changeset/swift-lions-work.md
+++ b/.changeset/swift-lions-work.md
@@ -2,4 +2,8 @@
 "kubernetes-agent": patch
 ---
 
-Bump Kubernetes Monitor chart to 0.40.0. This fixes a bug where child resources deleted while the monitor is offline linger in live status until the next periodic snapshot. See https://github.com/OctopusDeploy/helm-charts/issues/731 for more details.
+Bump Kubernetes Monitor chart to 0.40.0.
+
+- Fixes a bug where child resources deleted while the monitor is offline linger in live status until the next periodic snapshot
+- Adds a new `ReplaceDesiredResourcesCommand` for Octopus Server to send all desired resources together when monitor connects
+- See https://github.com/OctopusDeploy/helm-charts/issues/731 for more details

--- a/.changeset/swift-lions-work.md
+++ b/.changeset/swift-lions-work.md
@@ -2,4 +2,4 @@
 "kubernetes-agent": patch
 ---
 
-Bump Kubernetes Monitor chart to get rehydration fix
+Bump Kubernetes Monitor chart to 0.40.0

--- a/charts/kubernetes-agent/Chart.lock
+++ b/charts/kubernetes-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubernetes-monitor-chart
   repository: oci://docker.io/octopusdeploy
-  version: 0.39.0
-digest: sha256:a878241cbffc1d6913ecf70b6e6ab3476b69ebf1869e9e001dd3f4717b313146
-generated: "2026-08-28T16:39:25.884229+10:00"
+  version: 0.40.0
+digest: sha256:20323e6a54debc57d764f69ee4bf1c2d3b513fdd7093a239d64da69b28ee521b
+generated: "2026-09-01T11:42:13.102404+10:00"

--- a/charts/kubernetes-agent/Chart.yaml
+++ b/charts/kubernetes-agent/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     url: "https://octopus.com"
 dependencies:
   - name: kubernetes-monitor-chart
-    version: "0.39.0"
+    version: "0.40.0"
     repository: "oci://docker.io/octopusdeploy"
     condition: kubernetesMonitor.enabled
     alias: kubernetesMonitor


### PR DESCRIPTION
# Description

Fixes https://github.com/OctopusDeploy/Issues/issues/10207

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have added a changeset with an appropriate customer facing description.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
