### PR TITLE
Update workflow so it works with the new version of GA's

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -52,9 +52,9 @@ jobs:
       id: changesets
       uses: changesets/action@v2
       with:
-        commit: 'Version Charts'
-        title: 'Version Charts'
-        createGitHubReleases: false
+        commit-message: 'Version Charts'
+        pr-title: 'Version Charts'
+        create-github-releases: false
       env:
         GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
       


### PR DESCRIPTION
# Description

PR creation started failing after GA's were upgraded: https://github.com/OctopusDeploy/helm-charts/commit/0bfad95bf3ccb7fd3964b4c72613eed08568847f

Sample error:
https://github.com/OctopusDeploy/helm-charts/actions/runs/33477437924

<img width="830" height="312" alt="CleanShot 2026-09-02 at 10 30 17@2x" src="https://github.com/user-attachments/assets/47f5cdca-10e8-4fcb-8d19-281478031030" />

<!-- Why does this PR exist and what changes have been made? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
- [ ] I have considered appropriate testing for my change.
- [ ] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
