### PR TITLE
Fix changesets/action v2 token input and output names

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -55,8 +55,7 @@ jobs:
         commit-message: 'Version Charts'
         pr-title: 'Version Charts'
         create-github-releases: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
+        github-token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
       
     - name: Determine changed packages
       id: changed_packages
@@ -72,7 +71,7 @@ jobs:
         if [[ "$kaPackageVersion" != "$kaChartVersion" ]]; then
           echo "kaChartChanged=true" >> $GITHUB_OUTPUT
         fi
-      if: steps.changesets.outputs.hasChangesets == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true'
     
     - name: 'Update version in Octopus Deploy Chart.yaml'
       run: |
@@ -82,7 +81,7 @@ jobs:
         git config user.name "github-actions[bot]"
         git add charts/octopus-deploy/Chart.yaml
         git commit -m "Update chart version in charts/octopus-deploy/Chart.yaml"
-      if: steps.changesets.outputs.hasChangesets == 'true' && steps.changed_packages.outputs.odChartChanged == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true' && steps.changed_packages.outputs.odChartChanged == 'true'
         
 
     - name: 'Update version in Kubernetes Agent chart.yaml and pnpm-lock.yaml'
@@ -95,7 +94,7 @@ jobs:
         git add charts/kubernetes-agent/Chart.yaml
         git add pnpm-lock.yaml
         git commit -m "Update chart version in charts/kubernetes-agent/Chart.yaml and pnpm-lock.yaml"
-      if: steps.changesets.outputs.hasChangesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
 
     - name: 'Update version in Kubernetes Agent test snapshots'
       run: |
@@ -103,7 +102,7 @@ jobs:
         helm unittest -u charts/kubernetes-agent
         git add charts/kubernetes-agent/tests/__snapshot__/*
         git commit -m "Update chart version in Kubernetes agent test snapshots"
-      if: steps.changesets.outputs.hasChangesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
 
     - name: 'Update version in Kubernetes Agent Readme'
       working-directory: charts/kubernetes-agent
@@ -111,12 +110,12 @@ jobs:
         npm run generate-agent-docs
         git add README.md
         git commit -m "Update chart version in Kubernetes agent readme"
-      if: steps.changesets.outputs.hasChangesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true' && steps.changed_packages.outputs.kaChartChanged == 'true'
 
     - name: 'Push changes'
       run: |
         ref="${{ github.ref }}"
         ref=${ref#"refs/heads/"}
         git push --set-upstream origin "changeset-release/$ref"
-      if: steps.changesets.outputs.hasChangesets == 'true'
+      if: steps.changesets.outputs.has-changesets == 'true'
 


### PR DESCRIPTION
# Description

The Version Charts workflow is still broken after #735. Two `changesets/action` v2 breaking changes:

1. **Token** — v2 dropped `GITHUB_TOKEN` env support. The `github-token` input defaults to `github.token`, and the action errors when the env var is set and differs. Passed `CHANGESETS_GITHUB_TOKEN` to the input instead. ([failing run](https://github.com/OctopusDeploy/helm-charts/actions/runs/33579384807/job/100090225609))
2. **Outputs** — v2 renamed outputs to kebab-case. The six `hasChangesets` conditions were silently evaluating false, so every version-bump step and the push were skipped while the job reported success. Renamed to `has-changesets`.

Inputs have a `throwOnRenamedInputs` guard, outputs don't — so fixing only the token would have gone green while doing nothing.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
  - CI-only change, nothing customer facing ships from it.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
