### PR TITLE
Bump Version Charts workflow to Node 22

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: setup-node
       uses: actions/setup-node@v7
       with:
-        node-version: 20
+        node-version: 22
 
     - name: setup-helm
       uses: azure/setup-helm@v5.0.1


### PR DESCRIPTION
# Description

Third break from the same dependabot commit (5478edf), following #735 and #736.

That commit bumped `@changesets/cli` 2.29.8 -> 3.0.1, which requires `node: ^22.11 || ^24 || >=26`, but the workflow still pinned Node 20. The v3 CLI calls `module.enableCompileCache()` on module load, which does not exist before Node 22, so `changeset version` crashed immediately:

```
TypeError: enableCompileCache is not a function
  at @changesets/cli@3.0.1/bin.js:6:3     Node.js v20.20.2
```

Bumps the pin to Node 22 - the lowest supported LTS in that range. ([failing run](https://github.com/OctopusDeploy/helm-charts/actions/runs/33581243161/job/100095796748))

Verified by running the same `@changesets/cli@3.0.1` binary under Node 22, which loads cleanly. `cross-env@10.1.0` (the other package in that bump) only needs `node: >=20`, so changesets is the sole constraint.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
  - CI-only change, nothing customer facing ships from it.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
