### PR TITLE
Push version branch with the git CLI

### DIFF
--- a/.github/workflows/create-versioning-pr.yaml
+++ b/.github/workflows/create-versioning-pr.yaml
@@ -56,6 +56,7 @@ jobs:
         pr-title: 'Version Charts'
         create-github-releases: false
         github-token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
+        push-with-git-cli: true
       
     - name: Determine changed packages
       id: changed_packages


### PR DESCRIPTION
# Description

Fourth break from the same dependabot commit (5478edf), following #735, #736 and #737.

changesets/action v2 pushes release commits via the GitHub API by default instead of the git CLI, and in that mode it deliberately skips creating a local branch:

```js
async prepareBranch(branch) {
  if (!this.pushWithGitCli) {
    // Preparing a new local branch is not necessary when using the API
    return;
  }
  await switchToMaybeExistingBranch(branch, ...)
```

This workflow commits the Chart.yaml, test snapshot and README updates on top of the version commit and then pushes `changeset-release/<ref>` itself, so it needs that local branch to exist. Without it the push failed:

```
error: src refspec changeset-release/main does not match any
```

The action had already pushed its own files straight to the branch via the API, which is why #738 contained only the changesets-generated `CHANGELOG.md` and `package.json` and was missing Chart.yaml, the README and all six snapshots. ([failing run](https://github.com/OctopusDeploy/helm-charts/actions/runs/33589105035/job/100119267775))

`push-with-git-cli: true` restores the v1 behaviour the workflow relies on, and is the migration path called out in the v2 changelog.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have added a changeset with an appropriate customer facing description.
  - CI-only change, nothing customer facing ships from it.
- [x] I have considered appropriate testing for my change.
- [x] This PR affects all release versions and will need to be forward merged.
  - See the [documentation](https://github.com/OctopusDeploy/helm-charts/blob/main/charts/kubernetes-agent/docs/forward-merging-release-branches.md) if unsure of the process.
